### PR TITLE
Improve board visibility

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,25 +1,37 @@
 body {
     background-color: #f8f9fa;
 }
+
 #board {
     display: grid;
     grid-template-columns: repeat(3, 100px);
     grid-template-rows: repeat(3, 100px);
     gap: 5px;
+    margin: 0 auto;
+    width: max-content;
 }
+
 #board button {
     width: 100px;
     height: 100px;
     font-size: 2rem;
+    border: 1px solid #6c757d;
+    background-color: #e9ecef;
 }
+
 #memo-board {
     display: grid;
     grid-template-columns: repeat(4, 80px);
     grid-template-rows: repeat(4, 80px);
     gap: 5px;
+    margin: 0 auto;
+    width: max-content;
 }
+
 #memo-board button {
     width: 80px;
     height: 80px;
     font-size: 2rem;
+    background-color: #adb5bd;
+    border: 1px solid #6c757d;
 }


### PR DESCRIPTION
## Summary
- center both game boards
- add visible background for memo tiles
- add border and background for tic-tac-toe squares

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68485602b64883289f77688852c17511