### PR TITLE
Add 3D flip effect to memo game

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -29,9 +29,48 @@ body {
 }
 
 #memo-board button {
+    display: inline-block;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
     width: 80px;
     height: 80px;
+    perspective: 600px;
+}
+
+.memo-card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    transition: transform 0.6s;
+}
+
+.memo-card.flipped .memo-card-inner {
+    transform: rotateY(180deg);
+}
+
+.memo-card-front,
+.memo-card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 2rem;
-    background-color: #adb5bd;
+    box-sizing: border-box;
     border: 1px solid #6c757d;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.memo-card-back {
+    background-color: #adb5bd;
+}
+
+.memo-card-front {
+    background-color: #e9ecef;
+    transform: rotateY(180deg);
 }

--- a/js/memo.js
+++ b/js/memo.js
@@ -10,8 +10,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const deck = [...symbols, ...symbols].sort(() => Math.random() - 0.5);
         deck.forEach(sym => {
             const btn = document.createElement('button');
-            btn.className = 'btn btn-light';
+            btn.className = 'memo-card';
             btn.dataset.sym = sym;
+            btn.innerHTML = `<div class="memo-card-inner">` +
+                            `<div class="memo-card-front">${sym}</div>` +
+                            `<div class="memo-card-back"></div>` +
+                            `</div>`;
             btn.addEventListener('click', () => handleClick(btn));
             board.appendChild(btn);
         });
@@ -20,25 +24,31 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function handleClick(btn) {
-        if (lock || btn.disabled || btn === firstCard) return;
-        btn.textContent = btn.dataset.sym;
+        if (lock || btn.dataset.matched === 'true' || btn === firstCard) return;
+        btn.classList.add('flipped');
         if (!firstCard) {
             firstCard = btn;
             return;
         }
         lock = true;
         if (btn.dataset.sym === firstCard.dataset.sym) {
-            btn.disabled = true;
-            firstCard.disabled = true;
-            firstCard = null;
-            lock = false;
-            if ([...board.children].every(b => b.disabled)) {
-                setTimeout(() => alert('Wygrana!'), 300);
-            }
+            btn.dataset.matched = 'true';
+            firstCard.dataset.matched = 'true';
+            setTimeout(() => {
+                btn.classList.add('matched');
+                firstCard.classList.add('matched');
+                btn.disabled = true;
+                firstCard.disabled = true;
+                firstCard = null;
+                lock = false;
+                if ([...board.querySelectorAll('.memo-card')].every(b => b.dataset.matched === 'true')) {
+                    setTimeout(() => alert('Wygrana!'), 300);
+                }
+            }, 600);
         } else {
             setTimeout(() => {
-                btn.textContent = '';
-                firstCard.textContent = '';
+                btn.classList.remove('flipped');
+                firstCard.classList.remove('flipped');
                 firstCard = null;
                 lock = false;
             }, 700);


### PR DESCRIPTION
## Summary
- enhance memo board tiles with 3D flip animation and thickness
- update memo game script to use the flipping logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684891f68c88832896e91b4474262e9c