### PR TITLE
Add move counter to memory game

### DIFF
--- a/js/memo.js
+++ b/js/memo.js
@@ -1,12 +1,22 @@
 document.addEventListener('DOMContentLoaded', () => {
     const board = document.getElementById('memo-board');
     const resetBtn = document.getElementById('memo-reset');
-    const symbols = ['🍎','🍌','🍇','🍒','🍋','🍓','🍊','🍉'];
+    const status = document.getElementById('memo-status');
+    const sets = [
+        ['🍎','🍌','🍇','🍒','🍋','🍓','🍊','🍉'],
+        ['🐶','🐱','🐭','🐹','🐰','🦊','🐻','🐼'],
+        ['😀','😂','😎','😍','😡','🤢','🤠','🤖']
+    ];
+    let symbols = sets[0];
     let firstCard = null;
     let lock = false;
+    let moves = 0;
 
     function init() {
         board.innerHTML = '';
+        symbols = sets[Math.floor(Math.random() * sets.length)];
+        moves = 0;
+        status.textContent = 'Ruchy: 0';
         const deck = [...symbols, ...symbols].sort(() => Math.random() - 0.5);
         deck.forEach(sym => {
             const btn = document.createElement('button');
@@ -31,6 +41,8 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         lock = true;
+        moves++;
+        status.textContent = `Ruchy: ${moves}`;
         if (btn.dataset.sym === firstCard.dataset.sym) {
             btn.dataset.matched = 'true';
             firstCard.dataset.matched = 'true';
@@ -42,7 +54,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 firstCard = null;
                 lock = false;
                 if ([...board.querySelectorAll('.memo-card')].every(b => b.dataset.matched === 'true')) {
-                    setTimeout(() => alert('Wygrana!'), 300);
+                    setTimeout(() => {
+                        status.textContent = `Wygrana w ${moves} ruchach!`;
+                    }, 300);
                 }
             }, 600);
         } else {

--- a/memo.html
+++ b/memo.html
@@ -13,6 +13,7 @@
     <div class="container py-5">
         <h1 class="text-center mb-4">Memo (gra w pary)</h1>
         <div id="memo-board" class="mx-auto"></div>
+        <p id="memo-status" class="text-center mt-3"></p>
         <div class="text-center mt-3">
             <button id="memo-reset" class="btn btn-primary">Nowa gra</button>
             <a href="index.html" class="btn btn-secondary ms-2">Powrót</a>


### PR DESCRIPTION
## Summary
- show a status area below the memory board
- randomize symbol set for the board
- display move count and victory message without using alerts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684895b189608328921abefcb31d9f69