### PR TITLE
Add microbe attribute simulation

### DIFF
--- a/css/life.css
+++ b/css/life.css
@@ -12,9 +12,12 @@
     height: 20px;
     border: 1px solid #6c757d;
     background-color: #e9ecef;
-    cursor: pointer;
 }
 
-#life-board div.alive {
-    background-color: #198754;
+#life-board div.player {
+    background-color: #0d6efd;
+}
+
+#life-board div.enemy {
+    background-color: #dc3545;
 }

--- a/js/life.js
+++ b/js/life.js
@@ -1,10 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
     const board = document.getElementById('life-board');
     const startBtn = document.getElementById('life-start');
-    const stopBtn = document.getElementById('life-stop');
-    const randomBtn = document.getElementById('life-random');
+    const attackInput = document.getElementById('stat-attack');
+    const defenseInput = document.getElementById('stat-defense');
+    const speedInput = document.getElementById('stat-speed');
+    const remainingSpan = document.getElementById('points-remaining');
     const size = 20;
     let cells = [];
+    let microbes = [];
     let timer = null;
 
     function createBoard() {
@@ -14,7 +17,6 @@ document.addEventListener('DOMContentLoaded', () => {
             const row = [];
             for (let c = 0; c < size; c++) {
                 const cell = document.createElement('div');
-                cell.addEventListener('click', () => cell.classList.toggle('alive'));
                 board.appendChild(cell);
                 row.push(cell);
             }
@@ -22,51 +24,112 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function randomize() {
-        cells.forEach(row => row.forEach(cell => {
-            if (Math.random() > 0.7) cell.classList.add('alive');
-            else cell.classList.remove('alive');
-        }));
+    function updateRemaining() {
+        const total = +attackInput.value + +defenseInput.value + +speedInput.value;
+        remainingSpan.textContent = 10 - total;
     }
 
-    function countAlive(states, r, c) {
-        let count = 0;
-        for (let dr = -1; dr <= 1; dr++) {
-            for (let dc = -1; dc <= 1; dc++) {
-                if (dr === 0 && dc === 0) continue;
-                const rr = r + dr;
-                const cc = c + dc;
-                if (rr >= 0 && rr < size && cc >= 0 && cc < size && states[rr][cc]) {
-                    count++;
-                }
-            }
+    attackInput.addEventListener('input', updateRemaining);
+    defenseInput.addEventListener('input', updateRemaining);
+    speedInput.addEventListener('input', updateRemaining);
+
+    function randomStats() {
+        let points = 10;
+        const stats = {attack: 0, defense: 0, speed: 0};
+        const keys = Object.keys(stats);
+        while (points > 0) {
+            const k = keys[Math.floor(Math.random() * keys.length)];
+            stats[k]++;
+            points--;
         }
-        return count;
+        return stats;
+    }
+
+    function draw() {
+        cells.flat().forEach(c => {
+            c.className = '';
+        });
+        microbes.forEach(m => {
+            const cell = cells[m.y][m.x];
+            cell.classList.add(m.isPlayer ? 'player' : 'enemy');
+        });
+    }
+
+    function move(m) {
+        for (let s = 0; s < m.speed; s++) {
+            const dir = Math.floor(Math.random() * 4);
+            if (dir === 0 && m.y > 0) m.y--; // up
+            if (dir === 1 && m.y < size - 1) m.y++; // down
+            if (dir === 2 && m.x > 0) m.x--; // left
+            if (dir === 3 && m.x < size - 1) m.x++; // right
+        }
+    }
+
+    function fight(a, b) {
+        const aScore = a.attack + Math.random() * a.speed - b.defense;
+        const bScore = b.attack + Math.random() * b.speed - a.defense;
+        return aScore >= bScore ? b : a;
     }
 
     function step() {
-        const states = cells.map(row => row.map(cell => cell.classList.contains('alive')));
-        for (let r = 0; r < size; r++) {
-            for (let c = 0; c < size; c++) {
-                const alive = states[r][c];
-                const n = countAlive(states, r, c);
-                if (alive && (n < 2 || n > 3)) cells[r][c].classList.remove('alive');
-                else if (!alive && n === 3) cells[r][c].classList.add('alive');
+        microbes.forEach(move);
+        for (let i = microbes.length - 1; i >= 0; i--) {
+            for (let j = i - 1; j >= 0; j--) {
+                if (microbes[i].x === microbes[j].x && microbes[i].y === microbes[j].y) {
+                    const loser = fight(microbes[i], microbes[j]);
+                    microbes.splice(microbes.indexOf(loser), 1);
+                    if (loser.isPlayer) endGame(false);
+                    break;
+                }
             }
+        }
+        draw();
+        if (microbes.length === 1 && microbes[0].isPlayer) {
+            endGame(true);
         }
     }
 
-    startBtn.addEventListener('click', () => {
-        if (!timer) timer = setInterval(step, 300);
-    });
-
-    stopBtn.addEventListener('click', () => {
+    function endGame(win) {
         clearInterval(timer);
         timer = null;
+        setTimeout(() => {
+            alert(win ? 'Przetrwałeś!' : 'Twój organizm zginął.');
+        }, 10);
+    }
+
+    startBtn.addEventListener('click', () => {
+        const total = +attackInput.value + +defenseInput.value + +speedInput.value;
+        if (total > 10) {
+            alert('Za dużo punktów!');
+            return;
+        }
+        clearInterval(timer);
+        createBoard();
+        microbes = [];
+        const player = {
+            x: Math.floor(Math.random() * size),
+            y: Math.floor(Math.random() * size),
+            attack: +attackInput.value,
+            defense: +defenseInput.value,
+            speed: +speedInput.value,
+            isPlayer: true
+        };
+        microbes.push(player);
+        for (let i = 0; i < 5; i++) {
+            const s = randomStats();
+            microbes.push({
+                x: Math.floor(Math.random() * size),
+                y: Math.floor(Math.random() * size),
+                attack: s.attack,
+                defense: s.defense,
+                speed: s.speed,
+                isPlayer: false
+            });
+        }
+        draw();
+        timer = setInterval(step, 500);
     });
 
-    randomBtn.addEventListener('click', randomize);
-
     createBoard();
-    randomize();
+    updateRemaining();
 });

--- a/life.html
+++ b/life.html
@@ -12,11 +12,26 @@
 <body>
     <div class="container py-5">
         <h1 class="text-center mb-4">Gra w życie</h1>
+        <div id="life-config" class="mb-4">
+            <p>Pozostało punktów: <span id="points-remaining">10</span></p>
+            <div class="row g-2">
+                <div class="col">
+                    <label for="stat-attack" class="form-label">Atak</label>
+                    <input type="number" id="stat-attack" class="form-control" value="3" min="0" max="10">
+                </div>
+                <div class="col">
+                    <label for="stat-defense" class="form-label">Obrona</label>
+                    <input type="number" id="stat-defense" class="form-control" value="3" min="0" max="10">
+                </div>
+                <div class="col">
+                    <label for="stat-speed" class="form-label">Szybkość</label>
+                    <input type="number" id="stat-speed" class="form-control" value="4" min="0" max="10">
+                </div>
+            </div>
+        </div>
         <div id="life-board" class="mx-auto mb-3"></div>
         <div class="text-center">
             <button id="life-start" class="btn btn-success">Start</button>
-            <button id="life-stop" class="btn btn-warning ms-2">Stop</button>
-            <button id="life-random" class="btn btn-primary ms-2">Losuj</button>
             <a href="index.html" class="btn btn-secondary ms-2">Powrót</a>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- redesign life page with point allocation for attack/defense/speed
- simulate organism combat between the player's microbe and random microbes
- color player and enemy cells differently

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684899864a448328b66539a91e2c9955