### PR TITLE
Add slot animation to RPS game

### DIFF
--- a/css/rps.css
+++ b/css/rps.css
@@ -3,3 +3,13 @@
     width: 70px;
     height: 70px;
 }
+
+.rps-hidden {
+    visibility: hidden;
+}
+
+#rps-slot {
+    font-size: 3rem;
+    height: 70px;
+    line-height: 70px;
+}

--- a/js/rps.js
+++ b/js/rps.js
@@ -3,13 +3,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const status = document.getElementById('rps-status');
     const scoreSpan = document.getElementById('rps-score');
     const compSpan = document.getElementById('rps-comp');
+    const slot = document.getElementById('rps-slot');
     const resetBtn = document.getElementById('rps-reset');
     let score = 0;
     let comp = 0;
     const choices = ['rock', 'paper', 'scissors'];
+    const icons = {
+        rock: '👊',
+        paper: '✋',
+        scissors: '✌️'
+    };
 
-    function play(choice) {
-        const computer = choices[Math.floor(Math.random() * 3)];
+    function determineWinner(choice, computer) {
         if (choice === computer) {
             status.textContent = `Remis! Obaj wybraliście ${display(choice)}`;
         } else if (
@@ -27,6 +32,33 @@ document.addEventListener('DOMContentLoaded', () => {
         compSpan.textContent = comp;
     }
 
+    function play(choice) {
+        buttons.forEach(btn => {
+            btn.disabled = true;
+            if (btn.dataset.choice !== choice) {
+                btn.classList.add('rps-hidden');
+            }
+        });
+
+        status.textContent = '';
+        let i = 0;
+        const anim = setInterval(() => {
+            slot.textContent = icons[choices[i % 3]];
+            i++;
+        }, 100);
+
+        setTimeout(() => {
+            clearInterval(anim);
+            const computer = choices[Math.floor(Math.random() * 3)];
+            slot.textContent = icons[computer];
+            determineWinner(choice, computer);
+            buttons.forEach(btn => {
+                btn.disabled = false;
+                btn.classList.remove('rps-hidden');
+            });
+        }, 1000);
+    }
+
     function display(choice) {
         return choice === 'rock' ? 'kamień' : choice === 'paper' ? 'papier' : 'nożyce';
     }
@@ -41,5 +73,6 @@ document.addEventListener('DOMContentLoaded', () => {
         scoreSpan.textContent = '0';
         compSpan.textContent = '0';
         status.textContent = '';
+        slot.textContent = '';
     });
 });

--- a/rps.html
+++ b/rps.html
@@ -17,6 +17,7 @@
             <button class="btn btn-outline-primary me-2" data-choice="paper">✋</button>
             <button class="btn btn-outline-primary" data-choice="scissors">✌️</button>
         </div>
+        <div id="rps-slot" class="text-center mb-3"></div>
         <p id="rps-status" class="text-center mb-2"></p>
         <p class="text-center">Wynik: <span id="rps-score">0</span> : <span id="rps-comp">0</span></p>
         <div class="text-center">


### PR DESCRIPTION
## Summary
- add container for computer choice slot animation
- hide unselected options and animate computer choice
- style slot and hidden options for rock paper scissors

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849e85b9a808328b5242129782e6e65