### PR TITLE
Add Tetris game with onscreen controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ https://pawelwielga.github.io/chatgpt_codex_tests/index.html
 * **Wąż** – traditional Snake. Collect food to grow longer without hitting walls or yourself.
 * **Kamień, Papier, Nożyce** – simple duel against the computer. Choose your symbol and see who wins.
 * **Saper** – classic Minesweeper. Uncover all safe fields without detonating a mine.
+* **Tetris** – classic falling-block puzzle with on‑screen arrow controls.

--- a/css/tetris.css
+++ b/css/tetris.css
@@ -1,0 +1,15 @@
+#tetris-board {
+    display: grid;
+    grid-template-columns: repeat(10, 30px);
+    grid-template-rows: repeat(20, 30px);
+    gap: 1px;
+    margin: 0 auto;
+    width: max-content;
+}
+
+#tetris-board div {
+    width: 30px;
+    height: 30px;
+    border: 1px solid #6c757d;
+    background-color: #e9ecef;
+}

--- a/index.html
+++ b/index.html
@@ -72,6 +72,16 @@
                     </div>
                 </a>
             </div>
+            <div class="col">
+                <a href="tetris.html" class="text-decoration-none">
+                    <div class="card text-center h-100">
+                        <div class="card-body d-flex flex-column justify-content-center align-items-center">
+                            <i class="bi bi-stack" style="font-size: 3rem;"></i>
+                            <p class="mt-3 mb-0">Tetris</p>
+                        </div>
+                    </div>
+                </a>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/js/tetris.js
+++ b/js/tetris.js
@@ -1,0 +1,169 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const board = document.getElementById('tetris-board');
+    const startBtn = document.getElementById('tetris-start');
+    const scoreSpan = document.getElementById('tetris-score');
+    const btnRotate = document.getElementById('tetris-rotate');
+    const btnLeft = document.getElementById('tetris-left');
+    const btnRight = document.getElementById('tetris-right');
+    const btnDown = document.getElementById('tetris-down');
+
+    const width = 10;
+    const height = 20;
+    let cells = [];
+    let state = [];
+    let current = null;
+    let timer = null;
+    let score = 0;
+
+    const shapes = [
+        {color: '#0dcaf0', blocks: [[0,1],[1,1],[2,1],[3,1]]}, // I
+        {color: '#ffc107', blocks: [[0,0],[1,0],[0,1],[1,1]]}, // O
+        {color: '#6f42c1', blocks: [[1,0],[0,1],[1,1],[2,1]]}, // T
+        {color: '#198754', blocks: [[1,0],[2,0],[0,1],[1,1]]}, // S
+        {color: '#dc3545', blocks: [[0,0],[1,0],[1,1],[2,1]]}, // Z
+        {color: '#0d6efd', blocks: [[0,0],[0,1],[1,1],[2,1]]}, // J
+        {color: '#fd7e14', blocks: [[2,0],[0,1],[1,1],[2,1]]}  // L
+    ];
+
+    function createBoard() {
+        board.innerHTML = '';
+        cells = [];
+        state = [];
+        for (let r = 0; r < height; r++) {
+            const row = [];
+            state.push(Array(width).fill(null));
+            for (let c = 0; c < width; c++) {
+                const div = document.createElement('div');
+                board.appendChild(div);
+                row.push(div);
+            }
+            cells.push(row);
+        }
+    }
+
+    function draw() {
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                cells[y][x].style.backgroundColor = state[y][x] || '#e9ecef';
+            }
+        }
+        if (current) {
+            current.blocks.forEach(([bx, by]) => {
+                const x = current.x + bx;
+                const y = current.y + by;
+                if (y >= 0) {
+                    cells[y][x].style.backgroundColor = current.color;
+                }
+            });
+        }
+        scoreSpan.textContent = score;
+    }
+
+    function canMove(dx, dy, blocks = null) {
+        const shape = blocks || current.blocks;
+        for (const [bx, by] of shape) {
+            const x = current.x + bx + dx;
+            const y = current.y + by + dy;
+            if (x < 0 || x >= width || y >= height) return false;
+            if (y >= 0 && state[y][x]) return false;
+        }
+        return true;
+    }
+
+    function rotate() {
+        const rotated = current.blocks.map(([x, y]) => [y, -x]);
+        const minX = Math.min(...rotated.map(b => b[0]));
+        const minY = Math.min(...rotated.map(b => b[1]));
+        rotated.forEach(b => { b[0] -= minX; b[1] -= minY; });
+        if (canMove(0, 0, rotated)) {
+            current.blocks = rotated;
+            draw();
+        }
+    }
+
+    function move(dx, dy) {
+        if (canMove(dx, dy)) {
+            current.x += dx;
+            current.y += dy;
+            draw();
+            return true;
+        }
+        return false;
+    }
+
+    function mergePiece() {
+        current.blocks.forEach(([bx, by]) => {
+            const x = current.x + bx;
+            const y = current.y + by;
+            if (y >= 0) {
+                state[y][x] = current.color;
+            }
+        });
+    }
+
+    function clearLines() {
+        for (let y = height - 1; y >= 0; ) {
+            if (state[y].every(c => c)) {
+                state.splice(y, 1);
+                state.unshift(Array(width).fill(null));
+                score++;
+            } else {
+                y--;
+            }
+        }
+    }
+
+    function spawnPiece() {
+        const shape = shapes[Math.floor(Math.random() * shapes.length)];
+        current = {
+            x: 3,
+            y: -1,
+            blocks: shape.blocks.map(b => b.slice()),
+            color: shape.color
+        };
+        if (!canMove(0, 1)) {
+            endGame();
+        }
+    }
+
+    function step() {
+        if (!move(0, 1)) {
+            mergePiece();
+            clearLines();
+            spawnPiece();
+        }
+        draw();
+    }
+
+    function startGame() {
+        clearInterval(timer);
+        score = 0;
+        createBoard();
+        spawnPiece();
+        draw();
+        timer = setInterval(step, 500);
+    }
+
+    function endGame() {
+        clearInterval(timer);
+        timer = null;
+        draw();
+        alert('Koniec gry! Wynik: ' + score);
+    }
+
+    document.addEventListener('keydown', e => {
+        if (e.key === 'ArrowLeft') move(-1, 0);
+        if (e.key === 'ArrowRight') move(1, 0);
+        if (e.key === 'ArrowDown') step();
+        if (e.key === 'ArrowUp') rotate();
+    });
+
+    if (btnLeft) btnLeft.addEventListener('click', () => move(-1, 0));
+    if (btnRight) btnRight.addEventListener('click', () => move(1, 0));
+    if (btnDown) btnDown.addEventListener('click', () => step());
+    if (btnRotate) btnRotate.addEventListener('click', () => rotate());
+
+    startBtn.addEventListener('click', startGame);
+
+    createBoard();
+});

--- a/tetris.html
+++ b/tetris.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tetris</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="css/common.css" rel="stylesheet">
+    <link href="css/tetris.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container py-5">
+        <h1 class="text-center mb-4">Tetris</h1>
+        <div id="tetris-board" class="mb-3 mx-auto"></div>
+        <p class="text-center">Wynik: <span id="tetris-score">0</span></p>
+        <div id="tetris-controls" class="text-center mb-3">
+            <div class="d-flex flex-column align-items-center">
+                <button id="tetris-rotate" class="btn btn-outline-primary mb-2"><i class="bi bi-arrow-up"></i></button>
+                <div>
+                    <button id="tetris-left" class="btn btn-outline-primary me-2"><i class="bi bi-arrow-left"></i></button>
+                    <button id="tetris-down" class="btn btn-outline-primary me-2"><i class="bi bi-arrow-down"></i></button>
+                    <button id="tetris-right" class="btn btn-outline-primary"><i class="bi bi-arrow-right"></i></button>
+                </div>
+            </div>
+        </div>
+        <div class="text-center">
+            <button id="tetris-start" class="btn btn-success">Start</button>
+            <a href="index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/tetris.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Tetris to the list of available games
- implement Tetris game page
- implement game logic and board styling
- document new game in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849e918f2808328897c18043233d7a1