### PR TITLE
Modify cat buttons to use SVG cat head

### DIFF
--- a/css/calc.css
+++ b/css/calc.css
@@ -20,34 +20,26 @@ body {
     width: 70px;
     height: 70px;
     border: none;
-    background-color: #ff66cc;
-    color: #ffffff;
+    background: none;
     font-size: 1.5rem;
-    border-radius: 50%;
+    padding: 0;
+    color: #ff66cc;
 }
 
 .cat-button.operator {
-    background-color: #c266ff;
+    color: #c266ff;
 }
 
-.cat-button::before,
-.cat-button::after {
-    content: '';
+.cat-button svg {
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+}
+
+.cat-button span {
     position: absolute;
-    top: -18px;
-    width: 0;
-    height: 0;
-    border-left: 18px solid transparent;
-    border-right: 18px solid transparent;
-    border-bottom: 18px solid currentColor;
-}
-
-.cat-button::before {
-    left: 6px;
-    transform: rotate(-20deg);
-}
-
-.cat-button::after {
-    right: 6px;
-    transform: rotate(20deg);
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #ffffff;
 }

--- a/js/calc.js
+++ b/js/calc.js
@@ -10,9 +10,13 @@ document.addEventListener('DOMContentLoaded', () => {
         'C'
     ];
 
+    const svgPath = 'M10 55 Q10 35 30 30 L40 10 L50 30 L60 10 L70 30 Q90 35 90 55 Q90 80 50 90 Q10 80 10 55 Z';
+
     buttons.forEach(val => {
         const btn = document.createElement('button');
-        btn.textContent = val;
+        btn.innerHTML =
+            `<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><path d="${svgPath}"/></svg>`+
+            `<span>${val}</span>`;
         btn.dataset.value = val;
         btn.classList.add('cat-button');
         if ('/*-+=C'.includes(val)) {
@@ -22,8 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     grid.addEventListener('click', e => {
-        if (e.target.tagName !== 'BUTTON') return;
-        const value = e.target.dataset.value;
+        const target = e.target.closest('button');
+        if (!target) return;
+        const value = target.dataset.value;
         if (value === 'C') {
             display.value = '';
         } else if (value === '=') {


### PR DESCRIPTION
## Summary
- update catculator buttons to use an inline SVG cat head

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed0a2af083289ca0decd3f54d6e1