### PR TITLE
Modify Connect4 board layout

### DIFF
--- a/connect4/connect4.js
+++ b/connect4/connect4.js
@@ -12,20 +12,24 @@ document.addEventListener('DOMContentLoaded', () => {
     let animating = false;
     let cellSize = 60;
     let gapSize = 5;
+    let padSize = 5;
 
     function display(player) {
         return player === 'red' ? 'Czerwony' : 'Żółty';
     }
 
     function resizeBoard() {
-        const ratio = 5 / 60;
+        const ratio = 10 / 60;
         const maxWidth = Math.min(window.innerWidth - 20, 450);
-        cellSize = Math.floor(maxWidth / (cols + (cols - 1) * ratio));
+        const denom = cols + (cols - 1) * ratio + 2 * ratio;
+        cellSize = Math.floor(maxWidth / denom);
         gapSize = Math.round(cellSize * ratio);
-        const boardWidth = cellSize * cols + gapSize * (cols - 1);
-        const boardHeight = cellSize * rows + gapSize * (rows - 1);
+        padSize = gapSize;
+        const boardWidth = cellSize * cols + gapSize * (cols - 1) + padSize * 2;
+        const boardHeight = cellSize * rows + gapSize * (rows - 1) + padSize * 2;
         document.documentElement.style.setProperty('--cell-size', `${cellSize}px`);
         document.documentElement.style.setProperty('--gap-size', `${gapSize}px`);
+        document.documentElement.style.setProperty('--board-padding', `${padSize}px`);
         wrapperDiv.style.width = boardWidth + 'px';
         wrapperDiv.style.height = boardHeight + 'px';
         drawOverlay();
@@ -49,8 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
         for (let r = 0; r < rows; r++) {
             for (let c = 0; c < cols; c++) {
                 const circle = document.createElementNS(ns, 'circle');
-                circle.setAttribute('cx', c * (cellSize + gapSize) + cellSize / 2);
-                circle.setAttribute('cy', r * (cellSize + gapSize) + cellSize / 2);
+                circle.setAttribute('cx', padSize + c * (cellSize + gapSize) + cellSize / 2);
+                circle.setAttribute('cy', padSize + r * (cellSize + gapSize) + cellSize / 2);
                 circle.setAttribute('r', cellSize / 2);
                 circle.setAttribute('fill', 'black');
                 mask.appendChild(circle);
@@ -62,15 +66,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const boardRect = document.createElementNS(ns, 'rect');
         boardRect.setAttribute('width', '100%');
         boardRect.setAttribute('height', '100%');
-        boardRect.setAttribute('fill', '#0d6efd');
+        boardRect.setAttribute('fill', '#6c757d');
         boardRect.setAttribute('mask', 'url(#holes)');
         overlaySvg.appendChild(boardRect);
 
         for (let r = 0; r < rows; r++) {
             for (let c = 0; c < cols; c++) {
                 const outline = document.createElementNS(ns, 'circle');
-                outline.setAttribute('cx', c * (cellSize + gapSize) + cellSize / 2);
-                outline.setAttribute('cy', r * (cellSize + gapSize) + cellSize / 2);
+                outline.setAttribute('cx', padSize + c * (cellSize + gapSize) + cellSize / 2);
+                outline.setAttribute('cy', padSize + r * (cellSize + gapSize) + cellSize / 2);
                 outline.setAttribute('r', cellSize / 2);
                 outline.setAttribute('fill', 'none');
                 outline.setAttribute('stroke', '#6c757d');

--- a/css/connect4.css
+++ b/css/connect4.css
@@ -1,7 +1,8 @@
 :root {
     --cell-size: 60px;
     --gap-size: 5px;
-    --board-color: #0d6efd;
+    --board-padding: 5px;
+    --board-color: #6c757d;
 }
 
 #connect4-wrapper {
@@ -14,6 +15,8 @@
     grid-template-columns: repeat(7, var(--cell-size));
     grid-template-rows: repeat(6, var(--cell-size));
     gap: var(--gap-size);
+    padding: var(--board-padding);
+    box-sizing: border-box;
     width: 100%;
     height: 100%;
     background-color: var(--board-color);
@@ -53,7 +56,7 @@
     width: var(--cell-size);
     height: var(--cell-size);
     border-radius: 50%;
-    transition: top 0.3s linear;
+    transition: top 0.6s linear;
     pointer-events: none;
     z-index: 1;
 }


### PR DESCRIPTION
## Summary
- change board color to grey
- slow down disc drop animation
- enlarge spacing between holes and add padding from board edges

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a81ebb4e083289d061cf46b113475