### PR TITLE
Add QR-based WebRTC mode for Connect4

### DIFF
--- a/connect4/connect4.html
+++ b/connect4/connect4.html
@@ -12,6 +12,15 @@
 <body>
     <div class="container py-5">
         <h1 class="text-center mb-4">Connect 4</h1>
+        <div id="connect4-online" class="text-center mb-4">
+            <button id="host-btn" class="btn btn-success">Utwórz grę (host)</button>
+            <button id="join-btn" class="btn btn-warning ms-2">Dołącz do gry</button>
+        </div>
+        <div id="qr-container" class="text-center mb-4" style="display:none;">
+            <canvas id="qr-canvas" class="mb-2"></canvas>
+            <video id="qr-video" style="width:250px;" playsinline></video>
+            <p id="qr-text" class="mt-2"></p>
+        </div>
         <div id="connect4-wrapper" class="mb-3 mx-auto position-relative">
             <div id="connect4-board"></div>
             <svg id="connect4-overlay"></svg>
@@ -23,6 +32,8 @@
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
+    <script src="https://unpkg.com/qr-scanner@1.4.2/qr-scanner.umd.min.js"></script>
     <script src="connect4.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable hosting and joining Connect4 matches through WebRTC
- add QR‑code generation and scanning for exchanging offers/answers
- wire buttons for hosting/joining and move/board sync

## Testing
- `node --check connect4/connect4.js`

------
https://chatgpt.com/codex/tasks/task_e_684a8dbb636083289611644371eebe55