### PR TITLE
Refactor connection logic for Connect4

### DIFF
--- a/connect4/connect4.html
+++ b/connect4/connect4.html
@@ -34,6 +34,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
     <script src="https://unpkg.com/qr-scanner@1.4.2/qr-scanner.umd.min.js"></script>
+    <script src="../js/qrconnect.js"></script>
     <script src="connect4.js"></script>
 </body>
 </html>

--- a/js/qrconnect.js
+++ b/js/qrconnect.js
@@ -1,0 +1,81 @@
+const QrConnect = (() => {
+    let scanner = null;
+
+    function startScan(video, callback) {
+        scanner = new QrScanner(video, result => callback(result.data));
+        scanner.start();
+    }
+
+    function stopScan() {
+        if (scanner) {
+            scanner.stop();
+            scanner.destroy();
+            scanner = null;
+        }
+    }
+
+    function waitForIce(pc) {
+        return new Promise(res => {
+            if (pc.iceGatheringState === 'complete') {
+                res();
+            } else {
+                pc.onicegatheringstatechange = () => {
+                    if (pc.iceGatheringState === 'complete') res();
+                };
+            }
+        });
+    }
+
+    function showQr(canvas, data) {
+        QRCode.toCanvas(canvas, data);
+    }
+
+    async function showQrAndScan(elems, data) {
+        const {container, canvas, video} = elems;
+        container.style.display = 'block';
+        canvas.style.display = 'block';
+        video.style.display = 'block';
+        showQr(canvas, data);
+        return new Promise(resolve => {
+            startScan(video, resolve);
+        });
+    }
+
+    async function host(elems, label = 'data') {
+        const {text, container} = elems;
+        const pc = new RTCPeerConnection({iceServers:[{urls:'stun:stun.l.google.com:19302'}]});
+        const dc = pc.createDataChannel(label);
+        await pc.setLocalDescription(await pc.createOffer());
+        await waitForIce(pc);
+        text.textContent = 'Poczekaj na odpowiedź i zeskanuj kod';
+        const answer = await showQrAndScan(elems, JSON.stringify(pc.localDescription));
+        stopScan();
+        await pc.setRemoteDescription(JSON.parse(answer));
+        container.style.display = 'none';
+        return {pc, dc};
+    }
+
+    async function join(elems, label = 'data') {
+        const {text, container, canvas, video} = elems;
+        const pc = new RTCPeerConnection({iceServers:[{urls:'stun:stun.l.google.com:19302'}]});
+        let dc = null;
+        pc.ondatachannel = e => { dc = e.channel; };
+        text.textContent = 'Zeskanuj kod hosta';
+        container.style.display = 'block';
+        canvas.style.display = 'none';
+        video.style.display = 'block';
+        const offer = await new Promise(resolve => startScan(video, resolve));
+        stopScan();
+        await pc.setRemoteDescription(JSON.parse(offer));
+        await pc.setLocalDescription(await pc.createAnswer());
+        await waitForIce(pc);
+        text.textContent = 'Pokaż ten kod hostowi';
+        const confirm = await showQrAndScan(elems, JSON.stringify(pc.localDescription));
+        stopScan();
+        await pc.setRemoteDescription(JSON.parse(confirm));
+        container.style.display = 'none';
+        return {pc, dc};
+    }
+
+    return {host, join};
+})();


### PR DESCRIPTION
## Summary
- reuse QR based WebRTC connection logic
- use new shared file `qrconnect.js` for hosting or joining
- update Connect4 to rely on shared connection helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a93d2c20c83289d8e8d7a39196629