### PR TITLE
Add game mode icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-grid-3x3-gap" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kółko i Krzyżyk</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-cpu" title="Player vs PC" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -34,6 +37,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-layers" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Memo - gra w pary</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -44,6 +50,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-bug" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Gra w życie</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -54,6 +63,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-arrows-move" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Wąż</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -64,6 +76,10 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-hand-index" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kamień, Papier, Nożyce</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-cpu" title="Player vs PC" style="font-size: 1.2rem;"></i>
+                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -74,6 +90,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-flag" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Saper</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -84,6 +103,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-calculator" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Catculator</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            </div>
                            </div>
                     </div>
                 </a>
@@ -94,6 +116,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-stack" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Tetris</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -104,6 +129,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-circle-half" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Connect 4</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>
@@ -114,6 +142,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-record-fill" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Pong</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                            </div>
                         </div>
                     </div>
                 </a>


### PR DESCRIPTION
## Summary
- show small icons on game tiles for supported play modes

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684af2fe157c8328ac7633b68f45c894