### PR TITLE
Add PvP/PvE badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
                             <i class="bi bi-grid-3x3-gap" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kółko i Krzyżyk</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-cpu" title="Player vs PC" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
                             </div>
                         </div>
                     </div>
@@ -38,7 +38,7 @@
                             <i class="bi bi-layers" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Memo - gra w pary</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
                             </div>
                         </div>
                     </div>
@@ -51,7 +51,7 @@
                             <i class="bi bi-bug" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Gra w życie</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
                             </div>
                         </div>
                     </div>
@@ -64,7 +64,7 @@
                             <i class="bi bi-arrows-move" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Wąż</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
                             </div>
                         </div>
                     </div>
@@ -77,8 +77,8 @@
                             <i class="bi bi-hand-index" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kamień, Papier, Nożyce</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-cpu" title="Player vs PC" style="font-size: 1.2rem;"></i>
-                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
+                                <span class="badge text-bg-warning">PvP</span>
                             </div>
                         </div>
                     </div>
@@ -91,7 +91,7 @@
                             <i class="bi bi-flag" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Saper</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
                             </div>
                         </div>
                     </div>
@@ -104,7 +104,7 @@
                             <i class="bi bi-calculator" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Catculator</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
                             </div>
                            </div>
                     </div>
@@ -117,7 +117,7 @@
                             <i class="bi bi-stack" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Tetris</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success">PvE</span>
                             </div>
                         </div>
                     </div>
@@ -130,7 +130,7 @@
                             <i class="bi bi-circle-half" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Connect 4</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-warning">PvP</span>
                             </div>
                         </div>
                     </div>
@@ -143,7 +143,7 @@
                             <i class="bi bi-record-fill" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Pong</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-warning">PvP</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- switch PvP/PvE info to use Bootstrap badges instead of icons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684af4dba1b08328805ea71869371277