### PR TITLE
Add PvP/PvE badges with icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-grid-3x3-gap" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kółko i Krzyżyk</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-cpu" title="Player vs PC" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-cpu me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -37,8 +37,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-layers" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Memo - gra w pary</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -50,8 +50,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-bug" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Gra w życie</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -63,8 +63,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-arrows-move" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Wąż</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -76,9 +76,9 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-hand-index" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kamień, Papier, Nożyce</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-cpu" title="Player vs PC" style="font-size: 1.2rem;"></i>
-                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-cpu me-1"></i>PvE</span>
+                                <span class="badge text-bg-warning"><i class="bi bi-people me-1"></i>PvP</span>
                             </div>
                         </div>
                     </div>
@@ -90,8 +90,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-flag" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Saper</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -103,8 +103,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-calculator" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Catculator</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                            </div>
                     </div>
@@ -116,8 +116,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-stack" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Tetris</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -129,8 +129,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-circle-half" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Connect 4</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-warning"><i class="bi bi-people me-1"></i>PvP</span>
                             </div>
                         </div>
                     </div>
@@ -142,8 +142,8 @@
                         <div class="card-body d-flex flex-column justify-content-center align-items-center">
                             <i class="bi bi-record-fill" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Pong</p>
-                            <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                            <div class="d-flex gap-2 mt-2 align-items-center">
+                                <span class="badge text-bg-warning"><i class="bi bi-people me-1"></i>PvP</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- combine Bootstrap badges with the previous PvP/PvE icons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684af4dba1b08328805ea71869371277