### PR TITLE
Add icons back to PvE/PvP badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                             <i class="bi bi-grid-3x3-gap" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kółko i Krzyżyk</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-success">PvE</span>
+                                <span class="badge text-bg-success"><i class="bi bi-cpu me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -48,7 +48,7 @@
                             <i class="bi bi-layers" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Memo - gra w pary</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-success">PvE</span>
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -61,7 +61,7 @@
                             <i class="bi bi-bug" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Gra w życie</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-success">PvE</span>
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -74,7 +74,7 @@
                             <i class="bi bi-arrows-move" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Wąż</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-success">PvE</span>
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -87,8 +87,8 @@
                             <i class="bi bi-hand-index" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Kamień, Papier, Nożyce</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-success">PvE</span>
-                                <span class="badge text-bg-warning">PvP</span>
+                                <span class="badge text-bg-success"><i class="bi bi-cpu me-1"></i>PvE</span>
+                                <span class="badge text-bg-warning"><i class="bi bi-people me-1"></i>PvP</span>
                             </div>
                         </div>
                     </div>
@@ -101,7 +101,7 @@
                             <i class="bi bi-flag" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Saper</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-success">PvE</span>
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -114,7 +114,7 @@
                             <i class="bi bi-stack" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Tetris</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-success">PvE</span>
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>
@@ -127,7 +127,7 @@
                             <i class="bi bi-circle-half" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Connect 4</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-people" title="Player vs Player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-warning"><i class="bi bi-people me-1"></i>PvP</span>
                             </div>
                         </div>
                     </div>
@@ -140,7 +140,7 @@
                             <i class="bi bi-record-fill" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Pong</p>
                             <div class="d-flex gap-2 mt-2">
-                                <span class="badge text-bg-warning">PvP</span>
+                                <span class="badge text-bg-warning"><i class="bi bi-people me-1"></i>PvP</span>
                             </div>
                         </div>
                     </div>
@@ -157,7 +157,7 @@
                             <i class="bi bi-calculator" style="font-size: 3rem;"></i>
                             <p class="mt-3 mb-0">Catculator</p>
                             <div class="d-flex gap-2 mt-2">
-                                <i class="bi bi-person" title="Single player" style="font-size: 1.2rem;"></i>
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i>PvE</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- show CPU/person/people icons inside PvE and PvP badges

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684afa56233c832884f0271500b0b250