### PR TITLE
Fix badge icon alignment

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -10,6 +10,17 @@ body {
     background-color: #f8f9fa;
 }
 
+/* Center icons inside badges */
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.badge .bi {
+    margin: 0 !important;
+}
+
 body > footer {
     margin-top: auto;
 }


### PR DESCRIPTION
## Summary
- ensure icons inside badges are centered by switching the badge element to `inline-flex`
- remove margin from icons to avoid horizontal offset

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684afdf3b35883289737c102438d2ee1