### PR TITLE
Add player color badge

### DIFF
--- a/games/connect4/connect4.js
+++ b/games/connect4/connect4.js
@@ -287,6 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
     createBoard();
     updateNamesDisplay();
     if (infoP) {
-        infoP.textContent = `Grasz jako ${playerSettings.name} ${playerSettings.emoji}`;
+        const badge = `<span class="badge" style="background-color: ${playerSettings.color}; color: #fff;">${playerSettings.name} ${playerSettings.emoji}</span>`;
+        infoP.innerHTML = `Grasz jako ${badge}`;
     }
 });


### PR DESCRIPTION
## Summary
- show player name and emoji in a colored badge in Connect 4

## Testing
- `npx playwright test` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aff2ae5f48328a39a3a1b00306bcf