### PR TITLE
Add terrain system to Life game

### DIFF
--- a/css/life.css
+++ b/css/life.css
@@ -3,9 +3,33 @@
     width: 400px;
     height: 400px;
     margin: 0 auto;
-    background-color: #27ae60;
     overflow: hidden;
 }
+
+#terrain-layer, #entity-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+#terrain-layer {
+    display: grid;
+    grid-template-columns: repeat(20, 20px);
+    grid-template-rows: repeat(20, 20px);
+}
+
+.terrain-cell {
+    width: 20px;
+    height: 20px;
+}
+
+.water { background-color: #3498db; }
+.desert { background-color: #f0e68c; }
+.meadow { background-color: #27ae60; }
+.forest { background-color: #196F3D; }
+.mountain { background-color: #95a5a6; }
 
 .entity {
     position: absolute;


### PR DESCRIPTION
## Summary
- add terrain layers to Life board with new CSS classes
- implement terrain grid generation and rendering
- factor in terrain when moving, reproducing and spawning entities
- ensure players and microbes start on accessible ground

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b0d9136d88328af8a504448eeaf6b