### PR TITLE
Fix footer badge layout

### DIFF
--- a/js/index-badges.js
+++ b/js/index-badges.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const footer = document.querySelector('footer');
   if (footer) {
     const info = document.createElement('div');
-    info.className = 'small mt-2 d-flex flex-wrap justify-content-center gap-3 badge-legend';
+    info.className = 'small mt-2 d-flex flex-column align-items-center gap-2 badge-legend';
     info.innerHTML = `
       <span class="d-inline-flex align-items-center">
         <span class="badge text-bg-primary me-1"><i class="bi bi-cpu"></i></span>


### PR DESCRIPTION
## Summary
- arrange badge legend vertically so it's one column in the footer

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684b10778fbc83289bde92dcc45fc4a5