### PR TITLE
Add help popups to all games

### DIFF
--- a/games/connect4/connect4.html
+++ b/games/connect4/connect4.html
@@ -11,6 +11,9 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Connect 4</h1>
         <p class="text-center" id="player-info"></p>
         <div id="connect4-online" class="text-center mb-4">
@@ -29,6 +32,20 @@
         <div class="text-center mt-3">
             <button id="connect4-reset" class="btn btn-primary">Nowa gra</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Zrzucaj pionki do kolumn, by ułożyć cztery w rzędzie. Możesz grać lokalnie lub online po utworzeniu lub dołączeniu do gry.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/cube/cube.html
+++ b/games/cube/cube.html
@@ -17,10 +17,27 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Obrotowa Kostka 3D</h1>
         <div id="cube-container"></div>
         <div class="text-center mt-3">
             <a href="../../index.html" class="btn btn-secondary">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Przeciągaj myszą, aby obracać kostkę 3D i zobaczyć wszystkie jej strony.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script type="module" src="cube.js"></script>

--- a/games/hotpotato/hotpotato.html
+++ b/games/hotpotato/hotpotato.html
@@ -11,6 +11,9 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Gorący Ziemniak</h1>
         <div id="hp-online" class="text-center mb-3">
             <button id="hp-host" class="btn btn-success">Utwórz grę (host)</button>
@@ -28,6 +31,20 @@
         <div class="text-center">
             <button id="hp-start" class="btn btn-primary" style="display:none;">Start</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Przekazuj wirtualnego "ziemniaka" nim skończy się czas. Gracz, u którego zostanie, przegrywa.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/life/life.html
+++ b/games/life/life.html
@@ -11,6 +11,9 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Gra w życie</h1>
         <div id="life-config" class="mb-4">
             <p>Pozostało punktów: <span id="points-remaining">10</span></p>
@@ -57,6 +60,20 @@
         <div class="text-center">
             <button id="life-start" class="btn btn-success">Start</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Skonfiguruj cechy swojego stworzenia, a następnie obserwuj, jak radzi sobie w symulowanym środowisku.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/memo/memo.html
+++ b/games/memo/memo.html
@@ -11,12 +11,29 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Memo (gra w pary)</h1>
         <div id="memo-board" class="mx-auto"></div>
         <p id="memo-status" class="text-center mt-3"></p>
         <div class="text-center mt-3">
             <button id="memo-reset" class="btn btn-primary">Nowa gra</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Odkrywaj po dwie karty i znajdź wszystkie pary emoji w jak najmniejszej liczbie ruchów.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/minesweeper/minesweeper.html
+++ b/games/minesweeper/minesweeper.html
@@ -11,12 +11,29 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Saper (Minesweeper)</h1>
         <div id="mine-board" class="mb-3 mx-auto"></div>
         <p id="mine-status" class="text-center"></p>
         <div class="text-center mt-3">
             <button id="mine-reset" class="btn btn-primary">Nowa gra</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Odkrywaj pola i oznaczaj miny prawym przyciskiem. Usuń wszystkie pola bez detonacji.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/pong/pong.html
+++ b/games/pong/pong.html
@@ -11,12 +11,29 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Pong</h1>
         <canvas id="pong-canvas" width="400" height="300" class="mb-3"></canvas>
         <p class="text-center">Wynik: <span id="pong-score">0 : 0</span></p>
         <div class="text-center">
             <button id="pong-start" class="btn btn-success">Start</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Gracz lewy steruje klawiszami W/S, prawy strzałkami. Odbijaj piłkę i zdobądź więcej punktów niż przeciwnik.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/rps/rps.html
+++ b/games/rps/rps.html
@@ -11,6 +11,9 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Kamień, Papier, Nożyce</h1>
         <div id="rps-online" class="text-center mb-4">
             <button id="rps-host" class="btn btn-success">Utwórz grę (host)</button>
@@ -31,6 +34,20 @@
         <div class="text-center">
             <button id="rps-reset" class="btn btn-primary">Reset</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Wybierz jeden z symboli, aby zagrać rundę. Możesz grać lokalnie albo online.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/snake/snake.html
+++ b/games/snake/snake.html
@@ -11,6 +11,9 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Wąż - <span id="snake-player"></span></h1>
         <div id="snake-board" class="mb-3 mx-auto"></div>
         <p class="text-center">Wynik: <span id="snake-score">0</span></p>
@@ -27,6 +30,20 @@
         <div class="text-center">
             <button id="snake-start" class="btn btn-success">Start</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Kieruj wężem strzałkami lub przyciskami na ekranie. Zjadaj jedzenie i unikaj kolizji ze ścianami oraz z samym sobą.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/tetris/tetris.html
+++ b/games/tetris/tetris.html
@@ -11,6 +11,9 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Tetris</h1>
         <div id="tetris-board" class="mb-3 mx-auto"></div>
         <p class="text-center">Wynik: <span id="tetris-score">0</span></p>
@@ -27,6 +30,20 @@
         <div class="text-center">
             <button id="tetris-start" class="btn btn-success">Start</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Obracaj i przesuwaj spadające klocki tak, aby tworzyć pełne linie i zdobywać punkty.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/games/tictactoe/tictactoe.html
+++ b/games/tictactoe/tictactoe.html
@@ -11,12 +11,29 @@
 </head>
 <body>
     <div class="container py-5">
+        <div class="text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        </div>
         <h1 class="text-center mb-4">Kółko i Krzyżyk vs Komputer</h1>
         <div id="board" class="mx-auto"></div>
         <p id="ttt-status" class="text-center mt-3"></p>
         <div class="text-center mt-3">
             <button id="reset" class="btn btn-primary">Nowa gra</button>
             <a href="../../index.html" class="btn btn-secondary ms-2">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Klikaj pola, aby postawić swój znak. Ułóż linię z trzech symboli, zanim zrobi to komputer.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- add a help button at the top of every game page
- show a Bootstrap modal with instructions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b219f138c8328b63e1a1ec14ac834