### PR TITLE
Fix help button layout

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -30,3 +30,11 @@ body > footer {
     display: inline-flex;
     align-items: center;
 }
+
+/* Position the help button in the top-right corner of game containers */
+.help-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 0.5rem;
+}

--- a/games/connect4/connect4.html
+++ b/games/connect4/connect4.html
@@ -10,10 +10,8 @@
     <link href="../../css/connect4.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Connect 4</h1>
         <p class="text-center" id="player-info"></p>
         <div id="connect4-online" class="text-center mb-4">

--- a/games/cube/cube.html
+++ b/games/cube/cube.html
@@ -16,10 +16,8 @@
     </style>
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Obrotowa Kostka 3D</h1>
         <div id="cube-container"></div>
         <div class="text-center mt-3">

--- a/games/hotpotato/hotpotato.html
+++ b/games/hotpotato/hotpotato.html
@@ -10,10 +10,8 @@
     <link href="../../css/hotpotato.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Gorący Ziemniak</h1>
         <div id="hp-online" class="text-center mb-3">
             <button id="hp-host" class="btn btn-success">Utwórz grę (host)</button>

--- a/games/life/life.html
+++ b/games/life/life.html
@@ -10,10 +10,8 @@
     <link href="../../css/life.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Gra w życie</h1>
         <div id="life-config" class="mb-4">
             <p>Pozostało punktów: <span id="points-remaining">10</span></p>

--- a/games/memo/memo.html
+++ b/games/memo/memo.html
@@ -10,10 +10,8 @@
     <link href="../../css/memo.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Memo (gra w pary)</h1>
         <div id="memo-board" class="mx-auto"></div>
         <p id="memo-status" class="text-center mt-3"></p>

--- a/games/minesweeper/minesweeper.html
+++ b/games/minesweeper/minesweeper.html
@@ -10,10 +10,8 @@
     <link href="../../css/minesweeper.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Saper (Minesweeper)</h1>
         <div id="mine-board" class="mb-3 mx-auto"></div>
         <p id="mine-status" class="text-center"></p>

--- a/games/pong/pong.html
+++ b/games/pong/pong.html
@@ -10,10 +10,8 @@
     <link href="../../css/pong.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Pong</h1>
         <canvas id="pong-canvas" width="400" height="300" class="mb-3"></canvas>
         <p class="text-center">Wynik: <span id="pong-score">0 : 0</span></p>

--- a/games/rps/rps.html
+++ b/games/rps/rps.html
@@ -10,10 +10,8 @@
     <link href="../../css/rps.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Kamień, Papier, Nożyce</h1>
         <div id="rps-online" class="text-center mb-4">
             <button id="rps-host" class="btn btn-success">Utwórz grę (host)</button>

--- a/games/snake/snake.html
+++ b/games/snake/snake.html
@@ -10,10 +10,8 @@
     <link href="../../css/snake.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Wąż - <span id="snake-player"></span></h1>
         <div id="snake-board" class="mb-3 mx-auto"></div>
         <p class="text-center">Wynik: <span id="snake-score">0</span></p>

--- a/games/tetris/tetris.html
+++ b/games/tetris/tetris.html
@@ -10,10 +10,8 @@
     <link href="../../css/tetris.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Tetris</h1>
         <div id="tetris-board" class="mb-3 mx-auto"></div>
         <p class="text-center">Wynik: <span id="tetris-score">0</span></p>

--- a/games/tictactoe/tictactoe.html
+++ b/games/tictactoe/tictactoe.html
@@ -10,10 +10,8 @@
     <link href="../../css/tictactoe.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container py-5">
-        <div class="text-end">
-            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
-        </div>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Kółko i Krzyżyk vs Komputer</h1>
         <div id="board" class="mx-auto"></div>
         <p id="ttt-status" class="text-center mt-3"></p>


### PR DESCRIPTION
## Summary
- reposition help buttons so they don't push the board down
- centralize help button styling in `common.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b29d7b9288328aa5177d780698bde