### PR TITLE
Add card deck demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Bootstrap and Bootstrap Icons (loaded from a CDN) supply the basic layout and ic
 * **Connect 4** – drop discs to line up four in a row. You can play locally against another person, challenge the computer or set up an online match via PeerJS using short 5-character codes – no local server needed.
 * **Pong** – classic paddle and ball game for two players.
 * **Gorący Ziemniak** – prosta gra imprezowa dla wielu osób. Jeden z graczy trzyma "ziemniaka" i musi przekazać go dalej nim upłynie czas.
+* **Talia Kart** – prezentacja talii kart ułożonej na stoliku z lekkim efektem 3D.
 
 Most of the games are meant for local play but **Connect 4**, **Rock Paper Scissors** and **Gorący Ziemniak** also allow remote matches using the connection helpers described above. No external server is required – the games communicate directly between browsers.
 

--- a/css/cards.css
+++ b/css/cards.css
@@ -1,0 +1,34 @@
+#table {
+    width: 300px;
+    height: 200px;
+    margin: 0 auto;
+    background-color: #228B22;
+    border: 4px solid #6c757d;
+    border-radius: 8px;
+    position: relative;
+    perspective: 800px;
+    transform: rotateX(15deg);
+    box-shadow: 0 10px 20px rgba(0,0,0,0.3);
+}
+
+#deck {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform-style: preserve-3d;
+    transform: translate(-50%, -50%);
+}
+
+.card {
+    width: 60px;
+    height: 90px;
+    background-color: white;
+    border: 1px solid #6c757d;
+    border-radius: 4px;
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+}

--- a/games/cards/cards.html
+++ b/games/cards/cards.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Talia Kart</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="../../css/common.css" rel="stylesheet">
+    <link href="../../css/cards.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container py-5 position-relative">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        <h1 class="text-center mb-4">Talia Kart</h1>
+        <div id="table" class="mx-auto mb-4">
+            <div id="deck"></div>
+        </div>
+        <div class="text-center">
+            <a href="../../index.html" class="btn btn-secondary">Powrót</a>
+        </div>
+        <!-- Help Modal -->
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Ta strona pokazuje przykładową talię kart ułożoną na stole w lekkiej perspektywie 3D.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="cards.js"></script>
+    <script src="../../js/footer.js"></script>
+</body>
+</html>

--- a/games/cards/cards.js
+++ b/games/cards/cards.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const deckEl = document.getElementById('deck');
+    const suits = ['♠', '♥', '♦', '♣'];
+    const ranks = ['A','2','3','4','5','6','7','8','9','10','J','Q','K'];
+    let offset = 0;
+    for (const suit of suits) {
+        for (const rank of ranks) {
+            const card = document.createElement('div');
+            card.className = 'card';
+            card.textContent = `${rank}${suit}`;
+            card.style.transform = `translate(-50%, -50%) translateY(${-offset}px)`;
+            offset += 2;
+            deckEl.appendChild(card);
+        }
+    }
+});

--- a/index.html
+++ b/index.html
@@ -159,6 +159,19 @@
                     </div>
                 </a>
             </div>
+            <div class="col">
+                <a href="games/cards/cards.html" class="text-decoration-none">
+                    <div class="card text-center h-100">
+                        <div class="card-body d-flex flex-column justify-content-center align-items-center">
+                            <i class="bi bi-suit-spade-fill" style="font-size: 3rem;"></i>
+                            <p class="mt-3 mb-0">Talia Kart</p>
+                            <div class="d-flex gap-2 mt-2">
+                                <span class="badge text-bg-success"><i class="bi bi-person me-1"></i></span>
+                            </div>
+                        </div>
+                    </div>
+                </a>
+            </div>
         </div>
     </div>
     <div class="tab-pane fade" id="others" role="tabpanel" aria-labelledby="others-tab">


### PR DESCRIPTION
## Summary
- show a deck of cards on a 3D-looking table
- link the new demo from the index page
- document the new demo in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b3a609a348328a4ede540f93379fd