### PR TITLE
Adjust card table width for mobile

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -1,5 +1,6 @@
 #table {
-    width: 400px;
+    width: 100%;
+    max-width: 400px;
     height: 200px;
     margin: 0 auto;
     background-color: #228B22;


### PR DESCRIPTION
## Summary
- make the card table responsive so it doesn't exceed phone screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bc842fae48328a192d77d0c3cd0ce