### PR TITLE
Center deck and add lizard card backs

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -18,11 +18,9 @@
 #deck {
     position: absolute;
     top: 50%;
-    right: 20px;
+    left: 50%;
     transform-style: preserve-3d;
-    transform: translateY(-50%);
-    width: 60px;
-    height: 90px;
+    transform: translate(-50%, -50%);
 }
 
 .hand {
@@ -79,14 +77,13 @@
 
 .card.back,
 .deal-card.back {
-    background-color: #008000;
+    background-color: #0055aa;
     color: transparent;
     position: relative;
 }
 
 .card.back::after,
 .deal-card.back::after {
-    color: #fff;
     content: '🦎';
     position: absolute;
     left: 0;
@@ -97,4 +94,5 @@
     align-items: center;
     justify-content: center;
     font-size: 2rem;
+    color: #fff;
 }

--- a/games/cards/cards.js
+++ b/games/cards/cards.js
@@ -13,18 +13,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const suits = ['♠','♥','♦','♣'];
     const ranks = ['A','2','3','4','5','6','7','8','9','10','J','Q','K'];
 
-    // Show deck stacked in 3D with small offsets
-    let depth = 0;
+    // Show deck stacked in 3D
+    let offset = 0;
     for (const s of suits) {
         for (const r of ranks) {
             const card = document.createElement('div');
-            card.className = 'card back';
-            card.textContent = '';
-            card.style.left = '50%';
-            card.style.top = '50%';
-            const yShift = -Math.floor(depth / 5) * 2; // slight shift every few cards
-            card.style.transform = `translate(-50%, -50%) translateY(${yShift}px) translateZ(${depth}px)`;
-            depth += 1;
+            card.className = 'card';
+            card.textContent = `${r}${s}`;
+            card.style.transform = `translate(-50%, -50%) translateY(${-offset}px)`;
+            offset += 2;
             deckDiv.appendChild(card);
         }
     }


### PR DESCRIPTION
## Summary
- center the card deck again
- restore simple deck stacking logic
- show a lizard icon on card backs

## Testing
- `pre-commit` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdce458108328bffd6c63230aeedf