### PR TITLE
Fix card stacking CSS

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -79,7 +79,6 @@
 .deal-card.back {
     background-color: #0055aa;
     color: transparent;
-    position: relative;
 }
 
 .playing-card.back::after,


### PR DESCRIPTION
## Summary
- keep absolute positioning for facedown cards so deck stays stacked

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_684beaf8796483289d25afe3e1c503d8