### PR TITLE
Fix card dealing animation

### DIFF
--- a/games/cards/cards.js
+++ b/games/cards/cards.js
@@ -81,7 +81,6 @@ document.addEventListener('DOMContentLoaded', () => {
             target.appendChild(placeholder);
 
             const endWidth = target.scrollWidth;
-            const targetRect = placeholder.getBoundingClientRect();
 
             const temp = document.createElement('div');
             temp.className = 'deal-card';
@@ -93,6 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             requestAnimationFrame(() => {
                 target.style.width = endWidth + 'px';
+                const targetRect = placeholder.getBoundingClientRect();
                 temp.style.transform = `translate(${targetRect.left - deckRect.left}px, ${targetRect.top - deckRect.top}px)`;
             });
 


### PR DESCRIPTION
## Summary
- fix animation by measuring the placeholder only after expanding the hand

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c02327ae483288eba0fb9d37be471