### PR TITLE
Fix card visibility when dealing

### DIFF
--- a/games/cards/js/deal.js
+++ b/games/cards/js/deal.js
@@ -30,7 +30,8 @@ export function dealCard(deckDiv, card, target, faceUp) {
         temp.addEventListener('transitionend', () => {
             placeholder.textContent = faceUp ? card : '';
             if (faceUp) placeholder.classList.remove('back');
-            placeholder.style.visibility = '';
+            // Ensure the dealt card becomes visible once it reaches the hand
+            placeholder.style.visibility = 'visible';
             temp.remove();
             target.style.width = '';
             resolve();


### PR DESCRIPTION
## Summary
- make dealt cards visible when the transition finishes

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c07895f048328be488797b40b8a14