### PR TITLE
Fix hand card position and visibility

### DIFF
--- a/games/cards/js/deal.js
+++ b/games/cards/js/deal.js
@@ -13,6 +13,17 @@ export function dealCard(deckDiv, card, target, faceUp) {
 
         const endWidth = target.scrollWidth;
 
+        // Calculate the final card position without waiting for the width
+        // transition to finish. Temporarily disable the transition so the
+        // layout reflects the final width and we can measure the correct
+        // bounding box.
+        const originalTransition = target.style.transition;
+        target.style.transition = 'none';
+        target.style.width = endWidth + 'px';
+        const targetRect = placeholder.getBoundingClientRect();
+        target.style.width = startWidth + 'px';
+        target.style.transition = originalTransition;
+
         const temp = document.createElement('div');
         temp.className = 'deal-card';
         if (!faceUp) temp.classList.add('back');
@@ -23,7 +34,6 @@ export function dealCard(deckDiv, card, target, faceUp) {
 
         requestAnimationFrame(() => {
             target.style.width = endWidth + 'px';
-            const targetRect = placeholder.getBoundingClientRect();
             temp.style.transform = `translate(${targetRect.left - deckRect.left}px, ${targetRect.top - deckRect.top}px)`;
         });
 


### PR DESCRIPTION
## Summary
- improve width handling when dealing cards so hand remains centered

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c0b3604b08328bf5c138cb7c26010