### PR TITLE
Allow customizing computer look in Connect 4

### DIFF
--- a/games/connect4/connect4.js
+++ b/games/connect4/connect4.js
@@ -66,8 +66,8 @@ document.addEventListener('DOMContentLoaded', () => {
             players.red.emoji = playerSettings.emoji;
             if (newMode === 'ai') {
                 players.yellow.name = 'Komputer';
-                players.yellow.color = '#ffc107';
-                players.yellow.emoji = '💻';
+                players.yellow.color = playerSettings.aiColor;
+                players.yellow.emoji = playerSettings.aiEmoji;
             } else {
                 players.yellow.name = 'Żółty';
                 players.yellow.color = '#ffc107';

--- a/js/player-settings.js
+++ b/js/player-settings.js
@@ -1,7 +1,9 @@
 const playerSettings = {
     name: 'Gracz',
     color: '#dc3545',
-    emoji: '🐶'
+    emoji: '🐶',
+    aiColor: '#ffc107',
+    aiEmoji: '💻'
 };
 
 function loadPlayerSettings() {
@@ -12,6 +14,8 @@ function loadPlayerSettings() {
             if (data.name) playerSettings.name = data.name;
             if (data.color) playerSettings.color = data.color;
             if (data.emoji) playerSettings.emoji = data.emoji;
+            if (data.aiColor) playerSettings.aiColor = data.aiColor;
+            if (data.aiEmoji) playerSettings.aiEmoji = data.aiEmoji;
         } catch {}
     }
 }

--- a/settings.html
+++ b/settings.html
@@ -22,6 +22,14 @@
             <label for="settings-emoji" class="form-label">Emoji</label>
             <select id="settings-emoji" class="form-select"></select>
         </div>
+        <div class="mb-3">
+            <label for="settings-ai-color" class="form-label">Kolor komputera w Connect 4</label>
+            <input id="settings-ai-color" type="color" class="form-control form-control-color">
+        </div>
+        <div class="mb-3">
+            <label for="settings-ai-emoji" class="form-label">Emoji komputera w Connect 4</label>
+            <select id="settings-ai-emoji" class="form-select"></select>
+        </div>
         <div class="text-center">
             <button id="settings-save" class="btn btn-primary">Zapisz</button>
             <a href="index.html" class="btn btn-secondary ms-2">Powrót</a>
@@ -33,6 +41,8 @@
         const nameInput = document.getElementById('settings-name');
         const colorInput = document.getElementById('settings-color');
         const emojiSelect = document.getElementById('settings-emoji');
+        const aiColorInput = document.getElementById('settings-ai-color');
+        const aiEmojiSelect = document.getElementById('settings-ai-emoji');
         const saveBtn = document.getElementById('settings-save');
         const emojis = [
             "🐶","🐱","🐭","🐹","🐰","🦊","🐻","🐼","🐨","🐯","🦁",
@@ -45,14 +55,20 @@
             opt.value = e;
             opt.textContent = e;
             emojiSelect.appendChild(opt);
+            const opt2 = opt.cloneNode(true);
+            aiEmojiSelect.appendChild(opt2);
         });
         nameInput.value = playerSettings.name;
         colorInput.value = playerSettings.color;
         emojiSelect.value = playerSettings.emoji;
+        aiColorInput.value = playerSettings.aiColor;
+        aiEmojiSelect.value = playerSettings.aiEmoji;
         saveBtn.addEventListener('click', () => {
             playerSettings.name = nameInput.value.trim() || 'Gracz';
             playerSettings.color = colorInput.value;
             playerSettings.emoji = emojiSelect.value;
+            playerSettings.aiColor = aiColorInput.value;
+            playerSettings.aiEmoji = aiEmojiSelect.value;
             savePlayerSettings();
             window.location.href = 'index.html';
         });


### PR DESCRIPTION
## Summary
- add `aiColor` and `aiEmoji` fields to player settings
- extend settings page with color and emoji pickers for the computer
- use chosen settings for the computer player in Connect 4 AI mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c544f8348832899e77fa3a6bf1cf8