### PR TITLE
Add aquatic creatures to life simulation

### DIFF
--- a/games/life/life.html
+++ b/games/life/life.html
@@ -23,6 +23,10 @@
                 <label for="diet-select" class="form-label me-2">Dieta</label>
                 <select id="diet-select" class="form-select form-select-sm d-inline-block w-auto"></select>
             </div>
+            <div class="mb-2">
+                <label for="movement-select" class="form-label me-2">Ruch</label>
+                <select id="movement-select" class="form-select form-select-sm d-inline-block w-auto"></select>
+            </div>
             <div class="row g-2">
                 <div class="col text-center">
                     <label class="form-label">Atak</label>


### PR DESCRIPTION
## Summary
- add movement type selector and aquatic species
- spawn food on land or water
- make microbes respect water or land terrain
- central water reservoir

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c59279c6c8328862c3679022ecf61