### PR TITLE
Add card selection highlighting to Evo card demo

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -23,6 +23,31 @@
     transform: translate(-50%, -50%);
 }
 
+#board {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: grid;
+    grid-template-columns: repeat(3, 60px);
+    grid-template-rows: repeat(3, 90px);
+    gap: 10px;
+    pointer-events: none;
+}
+
+.board-slot {
+    width: 60px;
+    height: 90px;
+    border: 2px dashed rgba(255,255,255,0.6);
+    border-radius: 4px;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.board-slot.available {
+    opacity: 1;
+}
+
 .hand {
     position: absolute;
 
@@ -60,6 +85,10 @@
 .hand .playing-card {
     position: relative;
     flex-shrink: 0;
+}
+
+.playing-card.selected {
+    box-shadow: 0 0 0 2px #dc3545;
 }
 
 .placeholder {

--- a/games/cards/cards.html
+++ b/games/cards/cards.html
@@ -23,8 +23,9 @@
         <h4 id="cg-names" class="text-center mb-3" style="display:none;"></h4>
         <div id="table" class="mx-auto mb-4">
             <div id="deck"></div>
+            <div id="board"></div>
             <div id="my-hand" class="hand"></div>
-          <div id="opp-hand" class="hand"></div>
+            <div id="opp-hand" class="hand"></div>
         </div>
         <div class="text-center">
             <a href="../../index.html" class="btn btn-secondary">Powrót</a>

--- a/games/cards/js/main.js
+++ b/games/cards/js/main.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const deckDiv = document.getElementById('deck');
     const handDiv = document.getElementById('my-hand');
     const oppHandDiv = document.getElementById('opp-hand');
+    const boardDiv = document.getElementById('board');
     const hostBtn = document.getElementById('cg-host');
     const joinBtn = document.getElementById('cg-join');
     const qrDiv = document.getElementById('cg-qr');
@@ -30,6 +31,34 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function createBoard() {
+        for (let i = 0; i < 9; i++) {
+            const slot = document.createElement('div');
+            slot.className = 'board-slot';
+            boardDiv.appendChild(slot);
+        }
+    }
+    createBoard();
+
+    let selectedCard = null;
+
+    function addHandListeners() {
+        handDiv.querySelectorAll('.playing-card').forEach(card => {
+            card.addEventListener('click', () => {
+                if (selectedCard === card) {
+                    card.classList.remove('selected');
+                    selectedCard = null;
+                    boardDiv.querySelectorAll('.board-slot').forEach(s => s.classList.remove('available'));
+                } else {
+                    if (selectedCard) selectedCard.classList.remove('selected');
+                    selectedCard = card;
+                    card.classList.add('selected');
+                    boardDiv.querySelectorAll('.board-slot').forEach(s => s.classList.add('available'));
+                }
+            });
+        });
+    }
+
     let deck = [];
     let myCards = [];
     let dc = null;
@@ -50,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 updateNames();
                 myCards = msg.cards;
                 await dealHands(deckDiv, handDiv, oppHandDiv, myCards, new Array(myCards.length).fill(''), true, false);
+                addHandListeners();
             },
             onName: msg => {
                 opponentName = msg.name;
@@ -67,6 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const oppCards = deck.splice(0, 4);
         dc.send(JSON.stringify({ type: 'start', name: myName, cards: oppCards }));
         await dealHands(deckDiv, handDiv, oppHandDiv, myCards, new Array(oppCards.length).fill(''), true, false);
+        addHandListeners();
         updateNames();
     }
 


### PR DESCRIPTION
## Summary
- show a simple grid board for Evolution
- mark cards as selected and show board slots
- enable selection after dealing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c941efd888328976f7bf7acedbe07