### PR TITLE
Fix Angular CLI serve config

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/angular-cli",
   "version": 1,
-  "defaultProject": "browser-games-angular",
   "projects": {
     "browser-games-angular": {
       "projectType": "application",
@@ -29,7 +28,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "browser-games-angular:build"
+            "buildTarget": "browser-games-angular:build"
           }
         }
       }


### PR DESCRIPTION
## Summary
- fix `ng serve` configuration for Angular 20
- remove deprecated `defaultProject` property

## Testing
- `npm start` *(fails: NG6008 standalone components error)*

------
https://chatgpt.com/codex/tasks/task_e_684dec6b16748328bb1f5afe577b60c0