### PR TITLE
Update Catculator layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bootstrap and Bootstrap Icons (loaded from a CDN) supply the basic layout and ic
 * **Wąż** – traditional Snake. Collect food to grow longer without hitting walls or yourself.
 * **Kamień, Papier, Nożyce** – simple duel against the computer. Choose your symbol and see who wins.
 * **Saper** – classic Minesweeper. Uncover all safe fields without detonating a mine.
-* **Catculator** – basic calculator with pink and purple theme. The digit buttons are styled as cute cat heads and now include AC and DEL controls along with a history display.
+* **Catculator** – basic calculator with pink and purple theme. The digit buttons are styled as cute cat heads and now follow a cleaner layout with AC and = spanning two columns and digits ordered 1–9.
 * **Tetris** – classic falling-block puzzle with on‑screen arrow controls.
 * **Connect 4** – drop discs to line up four in a row. You can play locally against another person, challenge the computer or set up an online match via PeerJS using short 5-character codes – no local server needed.
 * **Pong** – classic paddle and ball game for two players.

--- a/css/calc.css
+++ b/css/calc.css
@@ -22,6 +22,10 @@ body {
     gap: 10px;
 }
 
+.span-2 {
+    grid-column: span 2;
+}
+
 .cat-button {
     position: relative;
     width: 70px;

--- a/other/calc/calc.js
+++ b/other/calc/calc.js
@@ -4,23 +4,37 @@ document.addEventListener('DOMContentLoaded', () => {
     const grid = document.getElementById('calc-buttons');
 
     const buttons = [
-        'AC','DEL','/','*',
-        '7','8','9','-',
-        '4','5','6','+',
-        '1','2','3','=',
-        '0','.'
+        { value: 'AC', classes: ['span-2'] },
+        { value: 'DEL' },
+        { value: '/' },
+        { value: '1' },
+        { value: '2' },
+        { value: '3' },
+        { value: '+' },
+        { value: '4' },
+        { value: '5' },
+        { value: '6' },
+        { value: '-' },
+        { value: '7' },
+        { value: '8' },
+        { value: '9' },
+        { value: '*' },
+        { value: '.' },
+        { value: '0' },
+        { value: '=', classes: ['span-2'] }
     ];
 
     const svgPath = 'M10 55 Q10 35 30 30 L40 10 L50 30 L60 10 L70 30 Q90 35 90 55 Q90 80 50 90 Q10 80 10 55 Z';
 
-    buttons.forEach(val => {
+    buttons.forEach(({ value, classes }) => {
         const btn = document.createElement('button');
         btn.innerHTML =
             `<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><path d="${svgPath}"/></svg>`+
-            `<span>${val}</span>`;
-        btn.dataset.value = val;
+            `<span>${value}</span>`;
+        btn.dataset.value = value;
         btn.classList.add('cat-button');
-        if ('/*-+=ACDEL'.includes(val)) {
+        if (classes) btn.classList.add(...classes);
+        if ('/*-+=ACDEL'.includes(value)) {
             btn.classList.add('operator');
         }
         grid.appendChild(btn);


### PR DESCRIPTION
## Summary
- arrange Catculator buttons to match reference layout
- support larger buttons with `.span-2`
- note cleaner Catculator layout in README

## Testing
- `node -e "require('fs').readFileSync('./other/calc/calc.js');" >/dev/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_685f2b1f86d88328b305b0e79ba33dfa