### PR TITLE
Refactor Catculator buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bootstrap and Bootstrap Icons (loaded from a CDN) supply the basic layout and ic
 * **Wąż** – traditional Snake. Collect food to grow longer without hitting walls or yourself.
 * **Kamień, Papier, Nożyce** – simple duel against the computer. Choose your symbol and see who wins.
 * **Saper** – classic Minesweeper. Uncover all safe fields without detonating a mine.
-* **Catculator** – basic calculator with pink and purple theme. The digit buttons are styled as cute cat heads and now follow a cleaner layout with AC and = spanning two columns and digits ordered 1–9.
+* **Catculator** – basic calculator with pink and purple theme. The digit buttons are styled as cute cat heads using pure CSS so wide buttons keep their round shape. They follow a cleaner layout with AC and = spanning two columns and digits ordered 1–9.
 * **Tetris** – classic falling-block puzzle with on‑screen arrow controls.
 * **Connect 4** – drop discs to line up four in a row. You can play locally against another person, challenge the computer or set up an online match via PeerJS using short 5-character codes – no local server needed.
 * **Pong** – classic paddle and ball game for two players.

--- a/css/calc.css
+++ b/css/calc.css
@@ -28,29 +28,55 @@ body {
 
 .cat-button {
     position: relative;
-    width: 70px;
+    width: 100%;
     height: 70px;
     border: none;
     background: none;
     font-size: 1.5rem;
     padding: 0;
     color: #ff66cc;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .cat-button.operator {
     color: #c266ff;
 }
 
-.cat-button svg {
-    width: 100%;
-    height: 100%;
-    fill: currentColor;
+.cat-face {
+    position: relative;
+    width: 70px;
+    height: 70px;
+    background-color: currentColor;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto;
 }
 
-.cat-button span {
+.cat-face::before,
+.cat-face::after {
+    content: "";
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    top: -20%;
+    width: 40%;
+    height: 40%;
+    background-color: currentColor;
+    border-radius: 50% 50% 0 0;
+}
+
+.cat-face::before {
+    left: 5%;
+    transform: rotate(-30deg);
+}
+
+.cat-face::after {
+    right: 5%;
+    transform: rotate(30deg);
+}
+
+.cat-face span {
     color: #ffffff;
 }

--- a/other/calc/calc.js
+++ b/other/calc/calc.js
@@ -24,13 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
         { value: '=', classes: ['span-2'] }
     ];
 
-    const svgPath = 'M10 55 Q10 35 30 30 L40 10 L50 30 L60 10 L70 30 Q90 35 90 55 Q90 80 50 90 Q10 80 10 55 Z';
-
     buttons.forEach(({ value, classes }) => {
         const btn = document.createElement('button');
-        btn.innerHTML =
-            `<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><path d="${svgPath}"/></svg>`+
-            `<span>${value}</span>`;
+        btn.innerHTML = `<span class="cat-face"><span>${value}</span></span>`;
         btn.dataset.value = value;
         btn.classList.add('cat-button');
         if (classes) btn.classList.add(...classes);


### PR DESCRIPTION
## Summary
- style cat head buttons with CSS instead of an SVG path
- keep wide buttons square by centering a fixed-size face
- mention the pure CSS approach in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f2da8a1e883288f73de50f9736e33