### PR TITLE
Refactor shared board styles

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -2,7 +2,6 @@
     width: 100%;
     max-width: 400px;
     height: 200px;
-    margin: 0 auto;
     background-color: #228B22;
     border: 4px solid #6c757d;
     border-radius: 8px;

--- a/css/common.css
+++ b/css/common.css
@@ -38,3 +38,26 @@ body > footer {
     right: 0;
     margin: 0.5rem;
 }
+
+/* Center common game boards horizontally */
+#board,
+#memo-board,
+#mine-board,
+#snake-board,
+#tetris-board,
+#life-board,
+#pong-canvas,
+#connect4-wrapper,
+#table {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* Boards using automatic width */
+#board,
+#memo-board,
+#mine-board,
+#snake-board,
+#tetris-board {
+    width: max-content;
+}

--- a/css/life.css
+++ b/css/life.css
@@ -2,7 +2,6 @@
     position: relative;
     width: 400px;
     height: 400px;
-    margin: 0 auto;
     overflow: hidden;
 }
 

--- a/css/memo.css
+++ b/css/memo.css
@@ -3,8 +3,6 @@
     grid-template-columns: repeat(4, 80px);
     grid-template-rows: repeat(4, 80px);
     gap: 5px;
-    margin: 0 auto;
-    width: max-content;
 }
 
 #memo-board button {

--- a/css/minesweeper.css
+++ b/css/minesweeper.css
@@ -3,8 +3,6 @@
     grid-template-columns: repeat(8, 30px);
     grid-template-rows: repeat(8, 30px);
     gap: 2px;
-    margin: 0 auto;
-    width: max-content;
 }
 
 #mine-board button {

--- a/css/pong.css
+++ b/css/pong.css
@@ -1,6 +1,5 @@
 #pong-canvas {
     display: block;
-    margin: 0 auto;
     background-color: #e9ecef;
     border: 2px solid #6c757d;
 }

--- a/css/snake.css
+++ b/css/snake.css
@@ -3,8 +3,6 @@
     grid-template-columns: repeat(20, 20px);
     grid-template-rows: repeat(20, 20px);
     gap: 1px;
-    margin: 0 auto;
-    width: max-content;
 }
 
 #snake-board div {

--- a/css/tetris.css
+++ b/css/tetris.css
@@ -3,8 +3,6 @@
     grid-template-columns: repeat(10, 30px);
     grid-template-rows: repeat(20, 30px);
     gap: 1px;
-    margin: 0 auto;
-    width: max-content;
 }
 
 #tetris-board div {

--- a/css/tictactoe.css
+++ b/css/tictactoe.css
@@ -3,8 +3,6 @@
     grid-template-columns: repeat(3, 100px);
     grid-template-rows: repeat(3, 100px);
     gap: 5px;
-    margin: 0 auto;
-    width: max-content;
 }
 
 #board button {


### PR DESCRIPTION
## Summary
- consolidate board centering rules in `common.css`
- remove duplicated centering rules from individual game stylesheets

## Testing
- `lynx -dump index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_687166bcf7f48328be8b8e70a59384c1