### PR TITLE
Add difficulty selector to Minesweeper

### DIFF
--- a/css/minesweeper.css
+++ b/css/minesweeper.css
@@ -1,7 +1,7 @@
 #mine-board {
     display: grid;
-    grid-template-columns: repeat(8, 30px);
-    grid-template-rows: repeat(8, 30px);
+    grid-template-columns: repeat(var(--size, 8), 30px);
+    grid-template-rows: repeat(var(--size, 8), 30px);
     gap: 2px;
 }
 

--- a/games/minesweeper/minesweeper.html
+++ b/games/minesweeper/minesweeper.html
@@ -13,6 +13,13 @@
     <div class="container py-5 position-relative">
         <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
         <h1 class="text-center mb-4">Saper (Minesweeper)</h1>
+        <div class="text-center mb-3">
+            <select id="mine-difficulty" class="form-select d-inline-block w-auto">
+                <option value="easy">Łatwy</option>
+                <option value="medium" selected>Średni</option>
+                <option value="hard">Trudny</option>
+            </select>
+        </div>
         <div id="mine-board" class="mb-3 mx-auto"></div>
         <p id="mine-status" class="text-center"></p>
         <div class="text-center mt-3">

--- a/games/minesweeper/minesweeper.js
+++ b/games/minesweeper/minesweeper.js
@@ -2,11 +2,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const boardEl = document.getElementById('mine-board');
     const resetBtn = document.getElementById('mine-reset');
     const statusEl = document.getElementById('mine-status');
-    const size = 8;
-    const mines = 10;
+    const difficultySelect = document.getElementById('mine-difficulty');
+    const DIFFICULTIES = {
+        easy: { size: 8, mines: 10 },
+        medium: { size: 12, mines: 25 },
+        hard: { size: 16, mines: 40 }
+    };
+    let size = 8;
+    let mines = 10;
     let board = [];
 
     function init() {
+        const diff = DIFFICULTIES[difficultySelect.value] || DIFFICULTIES.medium;
+        size = diff.size;
+        mines = diff.mines;
+        boardEl.style.setProperty('--size', size);
         boardEl.innerHTML = '';
         board = [];
         statusEl.textContent = '';
@@ -161,5 +171,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     resetBtn.addEventListener('click', init);
+    difficultySelect.addEventListener('change', init);
     init();
 });


### PR DESCRIPTION
## Summary
- add dropdown for choosing difficulty on Minesweeper page
- configure board CSS to use a CSS variable for dynamic size
- update Minesweeper logic to generate board based on selected difficulty

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_687aa2102d80832894071e4d46dcda85