### PR TITLE
[codex] Fix npm verification scripts and PR CI

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,1 +1,0 @@
-﻿module.exports = {\n  root: true,\n  env: { browser: true, es2022: true },\n  extends: ["eslint:recommended", "plugin:react/recommended", "plugin:react-hooks/recommended", "prettier"],\n  parserOptions: { ecmaVersion: "latest", sourceType: "module" },\n  settings: { react: { version: "detect" } },\n  rules: {},\n};\n

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run verification
+        run: npm run verify

--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ Run all merge checks:
 ```sh
 npm run verify
 ```
+
+## Pull request checks
+
+GitHub Actions runs the `CI / build-and-test` check for pull requests targeting `main`. The workflow installs dependencies with `npm ci` and then runs `npm run verify`.
+
+To block merging broken pull requests, configure branch protection or a repository ruleset for `main` and require the `build-and-test` status check to pass before merging.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Desktop Games
+
+React + Vite + TypeScript desktop-style collection of small browser games.
+
+## Development
+
+Install dependencies:
+
+```sh
+npm install
+```
+
+Start the local dev server:
+
+```sh
+npm run dev
+```
+
+Build the app:
+
+```sh
+npm run build
+```
+
+Preview the production build:
+
+```sh
+npm run preview
+```
+
+## Verification
+
+Run TypeScript checks:
+
+```sh
+npm run typecheck
+```
+
+Run the current lint baseline:
+
+```sh
+npm run lint
+```
+
+`lint` runs ESLint for JavaScript/config files and TypeScript checking for TS/TSX sources. A fuller type-aware ESLint setup can be added separately when the ESLint TypeScript parser is introduced.
+
+Run automated tests:
+
+```sh
+npm test
+```
+
+The project currently uses Node's built-in test runner. With no test files present, this command exits successfully and reports zero tests instead of failing as a placeholder.
+
+Run all merge checks:
+
+```sh
+npm run verify
+```

--- a/README.md
+++ b/README.md
@@ -63,3 +63,31 @@ npm run verify
 GitHub Actions runs the `CI / build-and-test` check for pull requests targeting `main`. The workflow installs dependencies with `npm ci` and then runs `npm run verify`.
 
 To block merging broken pull requests, configure branch protection or a repository ruleset for `main` and require the `build-and-test` status check to pass before merging.
+
+### Protecting `main`
+
+Use repository rulesets if they are available in the repository settings:
+
+1. Open the repository on GitHub.
+2. Go to `Settings` -> `Rules` -> `Rulesets`.
+3. Choose `New ruleset` -> `New branch ruleset`.
+4. Set a clear name, for example `Protect main`.
+5. Set `Enforcement status` to `Active`.
+6. In `Target branches`, add `main`.
+7. Enable `Require a pull request before merging`.
+8. Enable `Require status checks to pass`.
+9. Add the required check named `build-and-test`.
+10. Save the ruleset.
+
+If the repository uses the older branch protection screen instead:
+
+1. Open the repository on GitHub.
+2. Go to `Settings` -> `Branches`.
+3. Under `Branch protection rules`, choose `Add branch protection rule`.
+4. Set `Branch name pattern` to `main`.
+5. Enable `Require a pull request before merging`.
+6. Enable `Require status checks to pass before merging`.
+7. Search for and select the required check named `build-and-test`.
+8. Save the protection rule.
+
+After this, GitHub will block merging pull requests into `main` until the CI check passes.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ const browserGlobals = {
 
 export default [
   {
-    ignores: ["dist/**", "build/**", "coverage/**", "node_modules/**"],
+    ignores: ["build/**", "coverage/**", "dist/**", "legacy_backup/**", "node_modules/**", "public/**"],
   },
   js.configs.recommended,
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,42 @@
+import js from "@eslint/js";
+import prettier from "eslint-config-prettier";
+
+const browserGlobals = {
+  Blob: "readonly",
+  CanvasRenderingContext2D: "readonly",
+  Document: "readonly",
+  Element: "readonly",
+  Event: "readonly",
+  HTMLCanvasElement: "readonly",
+  HTMLElement: "readonly",
+  KeyboardEvent: "readonly",
+  MouseEvent: "readonly",
+  ResizeObserver: "readonly",
+  URL: "readonly",
+  console: "readonly",
+  document: "readonly",
+  localStorage: "readonly",
+  requestAnimationFrame: "readonly",
+  window: "readonly",
+};
+
+export default [
+  {
+    ignores: ["dist/**", "build/**", "coverage/**", "node_modules/**"],
+  },
+  js.configs.recommended,
+  {
+    files: ["**/*.{js,mjs,cjs,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: browserGlobals,
+    },
+  },
+  prettier,
+];

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "0.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "vite build",
     "dev": "vite",
-    "preview": "vite preview"
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit --pretty false",
+    "lint": "eslint . && npm run typecheck",
+    "test": "node --test",
+    "verify": "npm run typecheck && npm run lint && npm test && npm run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## What changed

- Added reliable npm scripts for `typecheck`, `lint`, `test`, and `verify`.
- Added GitHub Actions workflow `CI / build-and-test` for pull requests to `main` and pushes to `main`.
- Replaced the broken legacy ESLint config with an ESLint 9 flat config.
- Kept lint focused on active app/config files and excluded generated output plus `legacy_backup`.
- Added a root `README.md` documenting the current development, verification, and PR CI workflow.

## Why

Closes #118.

The previous `npm test` command was a placeholder that always failed. The project also had no explicit typecheck/lint/verify workflow documented for local development or CI.

## Validation

- Reviewed the branch diff against `main`.
- GitHub Actions `CI / build-and-test` passed on the PR head.

## Notes

`npm run lint` currently runs ESLint for JavaScript/config files and TypeScript checking for TS/TSX sources. A fuller type-aware ESLint setup can be handled by #119 when adding the TypeScript ESLint parser.

To block merges when CI fails, configure branch protection or a repository ruleset for `main` and require the `build-and-test` status check before merge.