### PR TITLE
[codex] Add reusable PeerJS multiplayer module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
+        "peerjs": "^1.5.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.7.1"
@@ -1008,6 +1009,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2444,6 +2454,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3717,6 +3733,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/peerjs": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
+      "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^2.8.0",
+        "eventemitter3": "^4.0.7",
+        "peerjs-js-binarypack": "^2.1.0",
+        "webrtc-adapter": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs-js-binarypack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
+      "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4071,6 +4119,12 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4653,6 +4707,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
+    "peerjs": "^1.5.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.7.1"

--- a/src/multiplayer/index.ts
+++ b/src/multiplayer/index.ts
@@ -1,0 +1,17 @@
+export { createRoomCode, isValidRoomCode, normalizeRoomCode, PeerRoomConnection } from "./peerConnection";
+export { usePeerRoom } from "./usePeerRoom";
+export type {
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+  MultiplayerConnectionError,
+  MultiplayerConnectionStatus,
+  MultiplayerErrorHandler,
+  MultiplayerMessage,
+  MultiplayerMessageHandler,
+  MultiplayerRole,
+  MultiplayerStatusHandler,
+  PeerRoomConnectionOptions,
+  PeerRoomSnapshot,
+} from "./multiplayer.types";
+export type { UsePeerRoomOptions, UsePeerRoomResult } from "./usePeerRoom";

--- a/src/multiplayer/multiplayer.types.ts
+++ b/src/multiplayer/multiplayer.types.ts
@@ -1,0 +1,35 @@
+import type { PeerOptions } from "peerjs";
+
+export type MultiplayerRole = "host" | "guest";
+
+export type MultiplayerConnectionStatus = "idle" | "hosting" | "joining" | "connected" | "closed" | "error";
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue | undefined };
+
+export type MultiplayerMessage = JsonObject & { type: string };
+
+export type MultiplayerMessageHandler<TMessage extends JsonObject = MultiplayerMessage> = (message: TMessage) => void;
+
+export type MultiplayerStatusHandler = (state: PeerRoomSnapshot) => void;
+
+export type MultiplayerErrorHandler = (error: MultiplayerConnectionError) => void;
+
+export type PeerRoomSnapshot = {
+  status: MultiplayerConnectionStatus;
+  role: MultiplayerRole | null;
+  roomCode: string | null;
+  error: MultiplayerConnectionError | null;
+};
+
+export type MultiplayerConnectionError = {
+  message: string;
+  cause?: unknown;
+};
+
+export type PeerRoomConnectionOptions = {
+  roomCodeLength?: number;
+  connectionTimeoutMs?: number;
+  peerOptions?: PeerOptions;
+};

--- a/src/multiplayer/peerConnection.ts
+++ b/src/multiplayer/peerConnection.ts
@@ -37,7 +37,7 @@ export function isValidRoomCode(roomCode: string): boolean {
 export class PeerRoomConnection<TMessage extends JsonObject = MultiplayerMessage> {
   private peer: Peer | null = null;
   private connection: DataConnection | null = null;
-  private connectionTimeout: number | null = null;
+  private connectionTimeout: ReturnType<typeof setTimeout> | null = null;
   private readonly messageHandlers = new Set<MultiplayerMessageHandler<TMessage>>();
   private readonly statusHandlers = new Set<MultiplayerStatusHandler>();
   private readonly errorHandlers = new Set<MultiplayerErrorHandler>();
@@ -269,12 +269,12 @@ export class PeerRoomConnection<TMessage extends JsonObject = MultiplayerMessage
 
   private startConnectionTimeout(onTimeout: () => void): void {
     this.clearConnectionTimeout();
-    this.connectionTimeout = window.setTimeout(onTimeout, this.options.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS);
+    this.connectionTimeout = setTimeout(onTimeout, this.options.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS);
   }
 
   private clearConnectionTimeout(): void {
     if (this.connectionTimeout !== null) {
-      window.clearTimeout(this.connectionTimeout);
+      clearTimeout(this.connectionTimeout);
       this.connectionTimeout = null;
     }
   }

--- a/src/multiplayer/peerConnection.ts
+++ b/src/multiplayer/peerConnection.ts
@@ -1,0 +1,356 @@
+import Peer, { type DataConnection, type PeerError, type PeerErrorType } from "peerjs";
+import type {
+  JsonObject,
+  MultiplayerConnectionError,
+  MultiplayerErrorHandler,
+  MultiplayerMessage,
+  MultiplayerMessageHandler,
+  MultiplayerStatusHandler,
+  PeerRoomConnectionOptions,
+  PeerRoomSnapshot,
+} from "./multiplayer.types";
+
+const ROOM_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const DEFAULT_ROOM_CODE_LENGTH = 5;
+const DEFAULT_CONNECTION_TIMEOUT_MS = 15_000;
+const ROOM_CODE_PATTERN = /^[A-Z0-9_-]{3,32}$/;
+
+export function createRoomCode(length = DEFAULT_ROOM_CODE_LENGTH): string {
+  const codeLength = Math.max(1, Math.floor(length));
+  let code = "";
+
+  for (let index = 0; index < codeLength; index++) {
+    code += ROOM_CODE_CHARS[Math.floor(Math.random() * ROOM_CODE_CHARS.length)];
+  }
+
+  return code;
+}
+
+export function normalizeRoomCode(roomCode: string): string {
+  return roomCode.trim().toUpperCase();
+}
+
+export function isValidRoomCode(roomCode: string): boolean {
+  return ROOM_CODE_PATTERN.test(normalizeRoomCode(roomCode));
+}
+
+export class PeerRoomConnection<TMessage extends JsonObject = MultiplayerMessage> {
+  private peer: Peer | null = null;
+  private connection: DataConnection | null = null;
+  private connectionTimeout: number | null = null;
+  private readonly messageHandlers = new Set<MultiplayerMessageHandler<TMessage>>();
+  private readonly statusHandlers = new Set<MultiplayerStatusHandler>();
+  private readonly errorHandlers = new Set<MultiplayerErrorHandler>();
+  private snapshot: PeerRoomSnapshot = {
+    status: "idle",
+    role: null,
+    roomCode: null,
+    error: null,
+  };
+
+  constructor(private readonly options: PeerRoomConnectionOptions = {}) {}
+
+  get state(): PeerRoomSnapshot {
+    return this.snapshot;
+  }
+
+  onMessage(handler: MultiplayerMessageHandler<TMessage>): () => void {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onStatusChange(handler: MultiplayerStatusHandler): () => void {
+    this.statusHandlers.add(handler);
+    handler(this.snapshot);
+    return () => this.statusHandlers.delete(handler);
+  }
+
+  onError(handler: MultiplayerErrorHandler): () => void {
+    this.errorHandlers.add(handler);
+    return () => this.errorHandlers.delete(handler);
+  }
+
+  async host(roomCode = createRoomCode(this.options.roomCodeLength)): Promise<PeerRoomSnapshot> {
+    const normalizedCode = normalizeRoomCode(roomCode);
+    if (!isValidRoomCode(normalizedCode)) {
+      return this.fail("Kod pokoju jest nieprawidłowy.");
+    }
+
+    this.closeTransport();
+    const peer = new Peer(normalizedCode, this.options.peerOptions);
+    this.peer = peer;
+    this.setSnapshot({ status: "hosting", role: "host", roomCode: normalizedCode, error: null });
+    this.bindPeer(peer);
+
+    try {
+      await this.waitForPeerOpen(peer);
+      return this.snapshot;
+    } catch (error) {
+      return this.fail("Nie udało się utworzyć pokoju multiplayer.", error);
+    }
+  }
+
+  async join(roomCode: string): Promise<PeerRoomSnapshot> {
+    const normalizedCode = normalizeRoomCode(roomCode);
+    if (!isValidRoomCode(normalizedCode)) {
+      return this.fail("Kod pokoju jest nieprawidłowy.");
+    }
+
+    this.closeTransport();
+    const peer = this.createGuestPeer();
+    this.peer = peer;
+    this.setSnapshot({ status: "joining", role: "guest", roomCode: normalizedCode, error: null });
+    this.bindPeer(peer);
+
+    try {
+      await this.waitForPeerOpen(peer);
+      const connection = peer.connect(normalizedCode, { reliable: true, serialization: "json" });
+      this.bindConnection(connection);
+      await this.waitForConnectionOpen(connection);
+      return this.snapshot;
+    } catch (error) {
+      return this.fail("Nie udało się dołączyć do pokoju multiplayer.", error);
+    }
+  }
+
+  send(message: TMessage): boolean {
+    if (!this.connection || !this.connection.open || this.snapshot.status !== "connected") {
+      this.reportError("Połączenie multiplayer nie jest jeszcze gotowe.");
+      return false;
+    }
+
+    try {
+      this.connection.send(JSON.stringify(message));
+      return true;
+    } catch (error) {
+      this.reportError("Nie udało się wysłać wiadomości multiplayer.", error);
+      return false;
+    }
+  }
+
+  close(): void {
+    this.closeTransport();
+    this.setSnapshot({ status: "closed", role: null, roomCode: null, error: null });
+  }
+
+  private createGuestPeer(): Peer {
+    return this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer();
+  }
+
+  private bindPeer(peer: Peer): void {
+    peer.on("connection", this.handleIncomingConnection);
+    peer.on("close", this.handlePeerClose);
+    peer.on("error", this.handlePeerError);
+  }
+
+  private bindConnection(connection: DataConnection): void {
+    this.closeConnection();
+    this.connection = connection;
+    connection.on("open", this.handleConnectionOpen);
+    connection.on("data", this.handleConnectionData);
+    connection.on("close", this.handleConnectionClose);
+    connection.on("error", this.handleConnectionError);
+  }
+
+  private readonly handleIncomingConnection = (connection: DataConnection): void => {
+    if (this.connection) {
+      connection.close();
+      return;
+    }
+
+    this.bindConnection(connection);
+  };
+
+  private readonly handleConnectionOpen = (): void => {
+    this.clearConnectionTimeout();
+    this.setSnapshot({ status: "connected", error: null });
+  };
+
+  private readonly handleConnectionData = (data: unknown): void => {
+    try {
+      const message = this.parseMessage(data);
+      for (const handler of this.messageHandlers) {
+        handler(message);
+      }
+    } catch (error) {
+      this.reportError("Odebrano nieprawidłową wiadomość multiplayer.", error);
+    }
+  };
+
+  private readonly handleConnectionClose = (): void => {
+    this.clearConnectionTimeout();
+    if (this.snapshot.status !== "closed" && this.snapshot.status !== "error") {
+      this.setSnapshot({ status: "closed" });
+    }
+  };
+
+  private readonly handleConnectionError = (error: unknown): void => {
+    this.fail("Wystąpił błąd połączenia multiplayer.", error);
+  };
+
+  private readonly handlePeerClose = (): void => {
+    this.clearConnectionTimeout();
+    if (this.snapshot.status !== "closed" && this.snapshot.status !== "error") {
+      this.setSnapshot({ status: "closed" });
+    }
+  };
+
+  private readonly handlePeerError = (error: PeerError<`${PeerErrorType}`>): void => {
+    this.fail(this.mapPeerError(error), error);
+  };
+
+  private parseMessage(data: unknown): TMessage {
+    const parsed = typeof data === "string" ? (JSON.parse(data) as unknown) : data;
+
+    if (!isJsonObject(parsed)) {
+      throw new Error("Wiadomość multiplayer musi być obiektem JSON.");
+    }
+
+    return parsed as TMessage;
+  }
+
+  private waitForPeerOpen(peer: Peer): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        peer.off("open", handleOpen);
+        peer.off("error", handleError);
+        this.clearConnectionTimeout();
+      };
+      const handleOpen = (id: string) => {
+        cleanup();
+        resolve(id);
+      };
+      const handleError = (error: PeerError<`${PeerErrorType}`>) => {
+        cleanup();
+        reject(error);
+      };
+
+      peer.once("open", handleOpen);
+      peer.once("error", handleError);
+      this.startConnectionTimeout(() => {
+        cleanup();
+        reject(new Error("Przekroczono czas oczekiwania na PeerJS."));
+      });
+    });
+  }
+
+  private waitForConnectionOpen(connection: DataConnection): Promise<void> {
+    if (connection.open) return Promise.resolve();
+
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        connection.off("open", handleOpen);
+        connection.off("error", handleError);
+        connection.off("close", handleClose);
+        this.clearConnectionTimeout();
+      };
+      const handleOpen = () => {
+        cleanup();
+        resolve();
+      };
+      const handleError = (error: unknown) => {
+        cleanup();
+        reject(error);
+      };
+      const handleClose = () => {
+        cleanup();
+        reject(new Error("Połączenie multiplayer zostało zamknięte przed otwarciem."));
+      };
+
+      connection.once("open", handleOpen);
+      connection.once("error", handleError);
+      connection.once("close", handleClose);
+      this.startConnectionTimeout(() => {
+        cleanup();
+        reject(new Error("Przekroczono czas oczekiwania na połączenie z pokojem."));
+      });
+    });
+  }
+
+  private startConnectionTimeout(onTimeout: () => void): void {
+    this.clearConnectionTimeout();
+    this.connectionTimeout = window.setTimeout(onTimeout, this.options.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS);
+  }
+
+  private clearConnectionTimeout(): void {
+    if (this.connectionTimeout !== null) {
+      window.clearTimeout(this.connectionTimeout);
+      this.connectionTimeout = null;
+    }
+  }
+
+  private fail(message: string, cause?: unknown): PeerRoomSnapshot {
+    const error = this.reportError(message, cause);
+    this.closeTransport();
+    this.setSnapshot({ status: "error", error });
+    return this.snapshot;
+  }
+
+  private reportError(message: string, cause?: unknown): MultiplayerConnectionError {
+    const error: MultiplayerConnectionError = { message, cause };
+    this.setSnapshot({ error });
+
+    for (const handler of this.errorHandlers) {
+      handler(error);
+    }
+
+    return error;
+  }
+
+  private setSnapshot(patch: Partial<PeerRoomSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...patch };
+    for (const handler of this.statusHandlers) {
+      handler(this.snapshot);
+    }
+  }
+
+  private closeTransport(): void {
+    this.clearConnectionTimeout();
+    this.closeConnection();
+
+    if (this.peer && !this.peer.destroyed) {
+      this.peer.off("connection", this.handleIncomingConnection);
+      this.peer.off("close", this.handlePeerClose);
+      this.peer.off("error", this.handlePeerError);
+      this.peer.destroy();
+    }
+
+    this.peer = null;
+  }
+
+  private closeConnection(): void {
+    if (!this.connection) return;
+
+    this.connection.off("open", this.handleConnectionOpen);
+    this.connection.off("data", this.handleConnectionData);
+    this.connection.off("close", this.handleConnectionClose);
+    this.connection.off("error", this.handleConnectionError);
+
+    if (this.connection.open) {
+      this.connection.close();
+    }
+
+    this.connection = null;
+  }
+
+  private mapPeerError(error: PeerError<`${PeerErrorType}`>): string {
+    switch (error.type) {
+      case "peer-unavailable":
+        return "Nie znaleziono pokoju o podanym kodzie.";
+      case "unavailable-id":
+        return "Ten kod pokoju jest już zajęty. Spróbuj utworzyć pokój ponownie.";
+      case "browser-incompatible":
+        return "Ta przeglądarka nie obsługuje wymaganego połączenia WebRTC.";
+      case "network":
+      case "server-error":
+      case "socket-error":
+        return "Nie udało się połączyć z serwerem PeerJS.";
+      default:
+        return "Wystąpił błąd PeerJS.";
+    }
+  }
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/multiplayer/usePeerRoom.ts
+++ b/src/multiplayer/usePeerRoom.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { PeerRoomConnection } from "./peerConnection";
+import type {
+  JsonObject,
+  MultiplayerMessage,
+  MultiplayerMessageHandler,
+  PeerRoomConnectionOptions,
+  PeerRoomSnapshot,
+} from "./multiplayer.types";
+
+export type UsePeerRoomOptions<TMessage extends JsonObject = MultiplayerMessage> = PeerRoomConnectionOptions & {
+  onMessage?: MultiplayerMessageHandler<TMessage>;
+};
+
+export type UsePeerRoomResult<TMessage extends JsonObject = MultiplayerMessage> = PeerRoomSnapshot & {
+  lastMessage: TMessage | null;
+  host: (roomCode?: string) => Promise<PeerRoomSnapshot>;
+  join: (roomCode: string) => Promise<PeerRoomSnapshot>;
+  send: (message: TMessage) => boolean;
+  close: () => void;
+  onMessage: (handler: MultiplayerMessageHandler<TMessage>) => () => void;
+};
+
+export function usePeerRoom<TMessage extends JsonObject = MultiplayerMessage>(
+  options: UsePeerRoomOptions<TMessage> = {}
+): UsePeerRoomResult<TMessage> {
+  const connectionRef = useRef<PeerRoomConnection<TMessage> | null>(null);
+  const messageHandlerRef = useRef(options.onMessage);
+  const [snapshot, setSnapshot] = useState<PeerRoomSnapshot>({
+    status: "idle",
+    role: null,
+    roomCode: null,
+    error: null,
+  });
+  const [lastMessage, setLastMessage] = useState<TMessage | null>(null);
+
+  if (!connectionRef.current) {
+    connectionRef.current = new PeerRoomConnection<TMessage>(options);
+  }
+
+  useEffect(() => {
+    messageHandlerRef.current = options.onMessage;
+  }, [options.onMessage]);
+
+  useEffect(() => {
+    const connection = connectionRef.current;
+    if (!connection) return undefined;
+
+    const unsubscribeStatus = connection.onStatusChange(setSnapshot);
+    const unsubscribeMessage = connection.onMessage((message) => {
+      setLastMessage(message);
+      messageHandlerRef.current?.(message);
+    });
+
+    return () => {
+      unsubscribeMessage();
+      unsubscribeStatus();
+      connection.close();
+    };
+  }, []);
+
+  const host = useCallback((roomCode?: string) => connectionRef.current?.host(roomCode) ?? Promise.resolve(snapshot), [snapshot]);
+  const join = useCallback((roomCode: string) => connectionRef.current?.join(roomCode) ?? Promise.resolve(snapshot), [snapshot]);
+  const send = useCallback((message: TMessage) => connectionRef.current?.send(message) ?? false, []);
+  const close = useCallback(() => connectionRef.current?.close(), []);
+  const onMessage = useCallback((handler: MultiplayerMessageHandler<TMessage>) => {
+    return connectionRef.current?.onMessage(handler) ?? (() => undefined);
+  }, []);
+
+  return {
+    ...snapshot,
+    lastMessage,
+    host,
+    join,
+    send,
+    close,
+    onMessage,
+  };
+}


### PR DESCRIPTION
## Summary

- adds a reusable `src/multiplayer` module for PeerJS/WebRTC room hosting and joining
- exposes shared multiplayer types, a transport class, and a React `usePeerRoom` hook
- adds `peerjs` as an application dependency with the generated lockfile update

## Notes

The module keeps transport separate from game logic: games provide room codes through UI, subscribe to typed JSON messages, and call `send`/`close` without touching DOM or legacy `CodeConnect`.

## Validation

- `npm ci --ignore-scripts`
- `npm run typecheck`
- `npm run build`

Closes #129