### PR TITLE
[codex] Add reusable multiplayer lobby and room protocol

### DIFF
--- a/src/desktop/Desktop.tsx
+++ b/src/desktop/Desktop.tsx
@@ -17,7 +17,7 @@ export default function Desktop(): React.ReactElement {
   // Centralize shortcut definitions; labels can later be i18n'ed
   const shortcuts: Shortcut[] = useMemo(
     () => [
-      { id: "tictactoe", icon: "🔢", label: "Kółko i Krzyżyk", implemented: false },
+      { id: "tictactoe", icon: "🔢", label: "Kółko i Krzyżyk", implemented: true },
       { id: "memo", icon: "🧠", label: "Memo", implemented: false },
       { id: "snake", icon: "🐍", label: "Wąż", implemented: true },
       { id: "rps", icon: "✊", label: "Kamień Papier Nożyce", implemented: false },

--- a/src/games/tictactoe/TicTacToeGame.tsx
+++ b/src/games/tictactoe/TicTacToeGame.tsx
@@ -1,0 +1,124 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { MultiplayerPanel, useMultiplayerLobby } from "@/multiplayer";
+import type { GameResetMessage, GameSpecificMessage } from "@/multiplayer";
+import "./tictactoe.css";
+
+type CellValue = "X" | "O" | null;
+type PlayerSymbol = Exclude<CellValue, null>;
+type TicTacToeMoveMessage = GameSpecificMessage<"tictactoe:move", { cell: number; symbol: PlayerSymbol }>;
+type TicTacToeMessage = TicTacToeMoveMessage | GameResetMessage;
+
+const WIN_LINES = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+] as const;
+
+export default function TicTacToeGame(): React.ReactElement {
+  const [board, setBoard] = useState<CellValue[]>(() => emptyBoard());
+  const [turn, setTurn] = useState<PlayerSymbol>("X");
+
+  const resetBoard = useCallback(() => {
+    setBoard(emptyBoard());
+    setTurn("X");
+  }, []);
+
+  const applyMove = useCallback((cell: number, symbol: PlayerSymbol) => {
+    if (!Number.isInteger(cell) || cell < 0 || cell >= 9) return;
+
+    setBoard((current) => {
+      if (current[cell] !== null) return current;
+      const next = current.slice();
+      next[cell] = symbol;
+      setTurn(symbol === "X" ? "O" : "X");
+      return next;
+    });
+  }, []);
+
+  const handleRemoteMessage = useCallback(
+    (message: TicTacToeMessage) => {
+      if (message.type === "game:reset") {
+        resetBoard();
+        return;
+      }
+
+      if (message.type === "tictactoe:move") {
+        applyMove(message.cell, message.symbol);
+      }
+    },
+    [applyMove, resetBoard]
+  );
+
+  const lobby = useMultiplayerLobby<TicTacToeMessage>({ onGameMessage: handleRemoteMessage });
+
+  const mySymbol: PlayerSymbol | null = lobby.role === "host" ? "X" : lobby.role === "guest" ? "O" : null;
+  const winner = useMemo(() => getWinner(board), [board]);
+  const draw = !winner && board.every(Boolean);
+  const canPlay = lobby.status === "connected" && mySymbol === turn && !winner && !draw;
+
+  const playCell = (cell: number) => {
+    if (!canPlay || !mySymbol || board[cell] !== null) return;
+    const sent = lobby.sendMessage({ type: "tictactoe:move", cell, symbol: mySymbol });
+    if (sent) applyMove(cell, mySymbol);
+  };
+
+  const resetGame = () => {
+    resetBoard();
+    if (lobby.status === "connected") {
+      lobby.sendMessage({ type: "game:reset" });
+    }
+  };
+
+  return (
+    <div className="ttt-root">
+      <MultiplayerPanel lobby={lobby} title="Kółko i Krzyżyk online" />
+
+      <section className="ttt-game" aria-label="Plansza Kółko i Krzyżyk">
+        <div className="ttt-status">
+          <span>Twój znak: {mySymbol ?? "połącz się"}</span>
+          <span>Tura: {turn}</span>
+          {winner && <strong>Wygrywa {winner}</strong>}
+          {draw && <strong>Remis</strong>}
+        </div>
+
+        <div className="ttt-board" role="grid" aria-label="Plansza 3 na 3">
+          {board.map((value, index) => (
+            <button
+              key={index}
+              type="button"
+              className="ttt-cell"
+              onClick={() => playCell(index)}
+              disabled={!canPlay || value !== null}
+              aria-label={`Pole ${index + 1}${value ? `, ${value}` : ""}`}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
+
+        <button type="button" className="ttt-reset" onClick={resetGame}>
+          Reset gry
+        </button>
+      </section>
+    </div>
+  );
+}
+
+function emptyBoard(): CellValue[] {
+  return Array<CellValue>(9).fill(null);
+}
+
+function getWinner(board: CellValue[]): PlayerSymbol | null {
+  for (const [a, b, c] of WIN_LINES) {
+    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
+      return board[a];
+    }
+  }
+
+  return null;
+}

--- a/src/games/tictactoe/tictactoe.css
+++ b/src/games/tictactoe/tictactoe.css
@@ -1,0 +1,61 @@
+.ttt-root {
+  display: grid;
+  gap: 14px;
+  height: 100%;
+  padding: 14px;
+  box-sizing: border-box;
+  overflow: auto;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.ttt-game {
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+}
+
+.ttt-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.ttt-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(72px, 112px));
+  gap: 8px;
+}
+
+.ttt-cell {
+  aspect-ratio: 1;
+  border: 1px solid rgba(125, 211, 252, 0.5);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.76);
+  color: #f8fafc;
+  font-size: clamp(32px, 10vw, 56px);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.ttt-cell:disabled {
+  cursor: default;
+  opacity: 0.88;
+}
+
+.ttt-cell:not(:disabled):hover {
+  background: rgba(14, 165, 233, 0.28);
+}
+
+.ttt-reset {
+  min-height: 36px;
+  border: 1px solid rgba(125, 211, 252, 0.55);
+  border-radius: 6px;
+  background: #0ea5e9;
+  color: #082f49;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0 14px;
+}

--- a/src/multiplayer/MultiplayerPanel.tsx
+++ b/src/multiplayer/MultiplayerPanel.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo, useState } from "react";
+import type { BaseMultiplayerMessage } from "./messages";
+import type { UseMultiplayerLobbyResult } from "./useMultiplayerLobby";
+import "./multiplayer-panel.css";
+
+export type MultiplayerPanelProps<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  lobby: UseMultiplayerLobbyResult<TGameMessage>;
+  title?: string;
+};
+
+export function MultiplayerPanel<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>({
+  lobby,
+  title = "Multiplayer",
+}: MultiplayerPanelProps<TGameMessage>): React.ReactElement {
+  const [joinCode, setJoinCode] = useState("");
+  const busy = lobby.status === "hosting" || lobby.status === "joining";
+  const connected = lobby.status === "connected";
+  const canJoin = joinCode.trim().length > 0 && !busy && !connected;
+
+  const statusText = useMemo(() => getStatusText(lobby), [lobby]);
+
+  return (
+    <section className="mp-panel" aria-label={title}>
+      <header className="mp-panel-header">
+        <div>
+          <h2>{title}</h2>
+          <p>{statusText}</p>
+        </div>
+        <div className="mp-local-player" title={lobby.localPlayer.name}>
+          <span aria-hidden style={{ color: lobby.localPlayer.color }}>
+            {lobby.localPlayer.emoji}
+          </span>
+          <strong>{lobby.localPlayer.name}</strong>
+        </div>
+      </header>
+
+      <div className="mp-actions">
+        <button type="button" onClick={() => void lobby.host()} disabled={busy || connected}>
+          Utwórz grę
+        </button>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (canJoin) void lobby.join(joinCode);
+          }}
+        >
+          <label htmlFor="mp-room-code">Kod pokoju</label>
+          <input
+            id="mp-room-code"
+            type="text"
+            value={joinCode}
+            onChange={(event) => setJoinCode(event.target.value.toUpperCase())}
+            placeholder="np. ABC12"
+            disabled={busy || connected}
+            autoComplete="off"
+          />
+          <button type="submit" disabled={!canJoin}>
+            Dołącz do gry
+          </button>
+        </form>
+      </div>
+
+      {lobby.roomCode && (
+        <div className="mp-room-code" role="status">
+          Kod pokoju: <strong>{lobby.roomCode}</strong>
+        </div>
+      )}
+
+      {lobby.error && <p className="mp-error">{lobby.error.message}</p>}
+
+      <div className="mp-players">
+        <span>Ty: {roleLabel(lobby.role)}</span>
+        {lobby.remotePlayers.length > 0 ? (
+          lobby.remotePlayers.map((player) => (
+            <span key={player.id}>
+              <span aria-hidden style={{ color: player.color }}>
+                {player.emoji}
+              </span>{" "}
+              {player.name}
+            </span>
+          ))
+        ) : (
+          <span>Przeciwnik: jeszcze nie połączony</span>
+        )}
+      </div>
+
+      {connected && (
+        <button type="button" className="mp-secondary" onClick={lobby.close}>
+          Rozłącz
+        </button>
+      )}
+    </section>
+  );
+}
+
+function getStatusText(lobby: UseMultiplayerLobbyResult): string {
+  switch (lobby.status) {
+    case "idle":
+      return "Utwórz pokój albo wpisz kod od hosta.";
+    case "hosting":
+      return "Czekaj na gracza...";
+    case "joining":
+      return "Łączenie...";
+    case "connected":
+      return "Połączono. Możecie grać.";
+    case "closed":
+      return "Połączenie zostało zamknięte.";
+    case "error":
+      return "Nie udało się połączyć.";
+    default:
+      return "Status połączenia nieznany.";
+  }
+}
+
+function roleLabel(role: UseMultiplayerLobbyResult["role"]): string {
+  if (role === "host") return "host";
+  if (role === "guest") return "gość";
+  return "brak roli";
+}
+
+export default MultiplayerPanel;

--- a/src/multiplayer/MultiplayerPanel.tsx
+++ b/src/multiplayer/MultiplayerPanel.tsx
@@ -8,6 +8,9 @@ export type MultiplayerPanelProps<TGameMessage extends BaseMultiplayerMessage = 
   title?: string;
 };
 
+type MultiplayerPanelStatus = UseMultiplayerLobbyResult<BaseMultiplayerMessage>["status"];
+type MultiplayerPanelRole = UseMultiplayerLobbyResult<BaseMultiplayerMessage>["role"];
+
 export function MultiplayerPanel<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>({
   lobby,
   title = "Multiplayer",
@@ -17,7 +20,7 @@ export function MultiplayerPanel<TGameMessage extends BaseMultiplayerMessage = B
   const connected = lobby.status === "connected";
   const canJoin = joinCode.trim().length > 0 && !busy && !connected;
 
-  const statusText = useMemo(() => getStatusText(lobby), [lobby]);
+  const statusText = useMemo(() => getStatusText(lobby.status), [lobby.status]);
 
   return (
     <section className="mp-panel" aria-label={title}>
@@ -93,8 +96,8 @@ export function MultiplayerPanel<TGameMessage extends BaseMultiplayerMessage = B
   );
 }
 
-function getStatusText(lobby: UseMultiplayerLobbyResult): string {
-  switch (lobby.status) {
+function getStatusText(status: MultiplayerPanelStatus): string {
+  switch (status) {
     case "idle":
       return "Utwórz pokój albo wpisz kod od hosta.";
     case "hosting":
@@ -112,7 +115,7 @@ function getStatusText(lobby: UseMultiplayerLobbyResult): string {
   }
 }
 
-function roleLabel(role: UseMultiplayerLobbyResult["role"]): string {
+function roleLabel(role: MultiplayerPanelRole): string {
   if (role === "host") return "host";
   if (role === "guest") return "gość";
   return "brak roli";

--- a/src/multiplayer/gameSession.types.ts
+++ b/src/multiplayer/gameSession.types.ts
@@ -1,5 +1,5 @@
 import type { MultiplayerConnectionError, MultiplayerConnectionStatus, MultiplayerRole } from "./multiplayer.types";
-import type { BaseMultiplayerMessage, PlayerProfile } from "./messages";
+import type { BaseMultiplayerMessage, OutgoingMultiplayerMessage, PlayerProfile } from "./messages";
 
 export type GameSessionRole = MultiplayerRole;
 
@@ -23,7 +23,7 @@ export type GameSessionSnapshot<TMessage extends BaseMultiplayerMessage = BaseMu
   roomCode: string | null;
   error: MultiplayerConnectionError | null;
   lastMessage: TMessage | null;
-  sendMessage: (message: Omit<TMessage, "sentAt"> & Partial<Pick<TMessage, "sentAt">>) => boolean;
+  sendMessage: (message: OutgoingMultiplayerMessage<TMessage>) => boolean;
 };
 
 export function getStartingTurn(role: GameSessionRole | null): TurnOwner | null {

--- a/src/multiplayer/gameSession.types.ts
+++ b/src/multiplayer/gameSession.types.ts
@@ -1,0 +1,32 @@
+import type { MultiplayerConnectionError, MultiplayerConnectionStatus, MultiplayerRole } from "./multiplayer.types";
+import type { BaseMultiplayerMessage, PlayerProfile } from "./messages";
+
+export type GameSessionRole = MultiplayerRole;
+
+export type TurnOwner = "host" | "guest";
+
+export type RemotePlayer = PlayerProfile & {
+  peerId: string;
+  connectedAt?: number;
+};
+
+export type LocalMultiplayerPlayer = PlayerProfile & {
+  role: GameSessionRole | null;
+};
+
+export type GameSessionSnapshot<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  role: GameSessionRole | null;
+  localPlayer: LocalMultiplayerPlayer;
+  remotePlayers: RemotePlayer[];
+  opponent: RemotePlayer | null;
+  status: MultiplayerConnectionStatus;
+  roomCode: string | null;
+  error: MultiplayerConnectionError | null;
+  lastMessage: TMessage | null;
+  sendMessage: (message: Omit<TMessage, "sentAt"> & Partial<Pick<TMessage, "sentAt">>) => boolean;
+};
+
+export function getStartingTurn(role: GameSessionRole | null): TurnOwner | null {
+  if (!role) return null;
+  return "host";
+}

--- a/src/multiplayer/hostClientRoom.types.ts
+++ b/src/multiplayer/hostClientRoom.types.ts
@@ -1,0 +1,23 @@
+import type { MultiplayerConnectionError } from "./multiplayer.types";
+import type { BaseMultiplayerMessage, PlayerProfile, RoomPlayersMessage } from "./messages";
+
+export type HostClientRoomStatus = "idle" | "hosting" | "joining" | "connected" | "closed" | "error";
+
+export type RemotePlayer = PlayerProfile & {
+  peerId: string;
+  connectedAt: number;
+};
+
+export type HostClientRoomEvent<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> =
+  | { type: "player-joined"; player: RemotePlayer }
+  | { type: "player-left"; player: RemotePlayer }
+  | { type: "message-received"; peerId: string; message: TMessage }
+  | { type: "room-closed" }
+  | { type: "error"; error: MultiplayerConnectionError };
+
+export type HostClientRoomMessage = BaseMultiplayerMessage | RoomPlayersMessage;
+
+export type HostClientRoomOptions<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  localPlayer?: PlayerProfile;
+  onEvent?: (event: HostClientRoomEvent<TMessage>) => void;
+};

--- a/src/multiplayer/index.ts
+++ b/src/multiplayer/index.ts
@@ -1,5 +1,19 @@
 export { createRoomCode, isValidRoomCode, normalizeRoomCode, PeerRoomConnection } from "./peerConnection";
 export { usePeerRoom } from "./usePeerRoom";
+export { MultiplayerPanel } from "./MultiplayerPanel";
+export { useMultiplayerLobby } from "./useMultiplayerLobby";
+export { usePeerHostRoom } from "./usePeerHostRoom";
+export { usePeerClientRoom } from "./usePeerClientRoom";
+export {
+  createMessage,
+  isMessageOfType,
+  isPlayerHelloMessage,
+  isPlayerProfile,
+  isRoomPlayersMessage,
+  onMessage,
+  parseMultiplayerMessage,
+  sendMessage,
+} from "./messages";
 export type {
   JsonObject,
   JsonPrimitive,
@@ -15,3 +29,34 @@ export type {
   PeerRoomSnapshot,
 } from "./multiplayer.types";
 export type { UsePeerRoomOptions, UsePeerRoomResult } from "./usePeerRoom";
+export type {
+  AnyMultiplayerMessage,
+  BaseMultiplayerMessage,
+  CommonMultiplayerMessage,
+  GameErrorMessage,
+  GameReadyMessage,
+  GameResetMessage,
+  GameSpecificMessage,
+  MessageMetadata,
+  MessageSend,
+  PlayerHelloMessage,
+  PlayerProfile,
+  RoomPlayersMessage,
+} from "./messages";
+export type {
+  GameSessionRole,
+  GameSessionSnapshot,
+  LocalMultiplayerPlayer,
+  RemotePlayer,
+  TurnOwner,
+} from "./gameSession.types";
+export type { MultiplayerLobbyStatus, UseMultiplayerLobbyOptions, UseMultiplayerLobbyResult } from "./useMultiplayerLobby";
+export type {
+  HostClientRoomEvent,
+  HostClientRoomMessage,
+  HostClientRoomOptions,
+  HostClientRoomStatus,
+  RemotePlayer as HostClientRemotePlayer,
+} from "./hostClientRoom.types";
+export type { UsePeerHostRoomResult } from "./usePeerHostRoom";
+export type { UsePeerClientRoomResult } from "./usePeerClientRoom";

--- a/src/multiplayer/index.ts
+++ b/src/multiplayer/index.ts
@@ -39,6 +39,7 @@ export type {
   GameSpecificMessage,
   MessageMetadata,
   MessageSend,
+  OutgoingMultiplayerMessage,
   PlayerHelloMessage,
   PlayerProfile,
   RoomPlayersMessage,

--- a/src/multiplayer/messages.ts
+++ b/src/multiplayer/messages.ts
@@ -11,6 +11,10 @@ export type BaseMultiplayerMessage<TType extends string = string> = JsonObject &
     type: TType;
   };
 
+export type OutgoingMultiplayerMessage<TMessage extends BaseMultiplayerMessage> = TMessage extends BaseMultiplayerMessage
+  ? Omit<TMessage, "sentAt" | "senderId"> & Partial<Pick<TMessage, "sentAt" | "senderId">>
+  : never;
+
 export type PlayerProfile = JsonObject & {
   id: string;
   name: string;

--- a/src/multiplayer/messages.ts
+++ b/src/multiplayer/messages.ts
@@ -35,8 +35,7 @@ export type GameErrorMessage = BaseMultiplayerMessage<"game:error"> & {
 
 export type CommonMultiplayerMessage = PlayerHelloMessage | GameResetMessage | GameReadyMessage | GameErrorMessage;
 
-export type GameSpecificMessage<TType extends string, TPayload extends JsonObject = JsonObject> = BaseMultiplayerMessage<TType> &
-  TPayload;
+export type GameSpecificMessage<TType extends string, TPayload = JsonObject> = BaseMultiplayerMessage<TType> & TPayload;
 
 export type AnyMultiplayerMessage = CommonMultiplayerMessage | BaseMultiplayerMessage;
 

--- a/src/multiplayer/messages.ts
+++ b/src/multiplayer/messages.ts
@@ -1,0 +1,139 @@
+import type { JsonObject, JsonValue, MultiplayerMessageHandler } from "./multiplayer.types";
+
+export type MessageMetadata = {
+  requestId?: string;
+  senderId?: string;
+  sentAt?: number;
+};
+
+export type BaseMultiplayerMessage<TType extends string = string> = JsonObject &
+  MessageMetadata & {
+    type: TType;
+  };
+
+export type PlayerProfile = JsonObject & {
+  id: string;
+  name: string;
+  color: string;
+  emoji: string;
+};
+
+export type PlayerHelloMessage = BaseMultiplayerMessage<"player:hello"> & {
+  player: PlayerProfile;
+};
+
+export type GameResetMessage = BaseMultiplayerMessage<"game:reset">;
+
+export type GameReadyMessage = BaseMultiplayerMessage<"game:ready"> & {
+  ready?: boolean;
+};
+
+export type GameErrorMessage = BaseMultiplayerMessage<"game:error"> & {
+  message: string;
+  code?: string;
+};
+
+export type CommonMultiplayerMessage = PlayerHelloMessage | GameResetMessage | GameReadyMessage | GameErrorMessage;
+
+export type GameSpecificMessage<TType extends string, TPayload extends JsonObject = JsonObject> = BaseMultiplayerMessage<TType> &
+  TPayload;
+
+export type AnyMultiplayerMessage = CommonMultiplayerMessage | BaseMultiplayerMessage;
+
+export type MessageSend<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = (message: TMessage) => boolean;
+
+export function createMessage<TMessage extends BaseMultiplayerMessage>(
+  message: Omit<TMessage, "sentAt"> & Partial<Pick<TMessage, "sentAt">>
+): TMessage {
+  return {
+    ...message,
+    sentAt: message.sentAt ?? Date.now(),
+  } as TMessage;
+}
+
+export function sendMessage<TMessage extends BaseMultiplayerMessage>(
+  send: MessageSend<TMessage>,
+  message: Omit<TMessage, "sentAt"> & Partial<Pick<TMessage, "sentAt">>
+): boolean {
+  return send(createMessage<TMessage>(message));
+}
+
+export function onMessage<TMessage extends BaseMultiplayerMessage>(
+  handler: MultiplayerMessageHandler<TMessage>,
+  onInvalid?: (data: unknown) => void
+): MultiplayerMessageHandler<JsonObject> {
+  return (data) => {
+    const message = parseMultiplayerMessage<TMessage>(data);
+    if (!message) {
+      onInvalid?.(data);
+      return;
+    }
+
+    handler(message);
+  };
+}
+
+export function parseMultiplayerMessage<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>(
+  data: unknown
+): TMessage | null {
+  let parsed: unknown = data;
+
+  if (typeof data === "string") {
+    try {
+      parsed = JSON.parse(data) as unknown;
+    } catch {
+      return null;
+    }
+  }
+
+  if (!isJsonObject(parsed) || typeof parsed.type !== "string" || parsed.type.trim().length === 0) {
+    return null;
+  }
+
+  if (parsed.requestId !== undefined && typeof parsed.requestId !== "string") return null;
+  if (parsed.senderId !== undefined && typeof parsed.senderId !== "string") return null;
+  if (parsed.sentAt !== undefined && typeof parsed.sentAt !== "number") return null;
+
+  return parsed as TMessage;
+}
+
+export function isMessageOfType<TType extends string>(
+  message: BaseMultiplayerMessage,
+  type: TType
+): message is BaseMultiplayerMessage<TType> {
+  return message.type === type;
+}
+
+export function isPlayerProfile(value: unknown): value is PlayerProfile {
+  return (
+    isJsonObject(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.color === "string" &&
+    typeof value.emoji === "string"
+  );
+}
+
+export function isPlayerHelloMessage(message: BaseMultiplayerMessage): message is PlayerHelloMessage {
+  return message.type === "player:hello" && isPlayerProfile(message.player);
+}
+
+export function isRoomPlayersMessage(message: BaseMultiplayerMessage): message is RoomPlayersMessage {
+  return message.type === "room:players" && Array.isArray(message.players) && message.players.every(isPlayerProfile);
+}
+
+export type RoomPlayersMessage = GameSpecificMessage<"room:players", { players: PlayerProfile[] }>;
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value) && isJsonValue(value);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+  if (["string", "number", "boolean"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).every((item) => item === undefined || isJsonValue(item));
+  }
+  return false;
+}

--- a/src/multiplayer/multiplayer-panel.css
+++ b/src/multiplayer/multiplayer-panel.css
@@ -1,0 +1,108 @@
+.mp-panel {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.76);
+  color: #f8fafc;
+}
+
+.mp-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mp-panel h2,
+.mp-panel p {
+  margin: 0;
+}
+
+.mp-panel h2 {
+  font-size: 16px;
+}
+
+.mp-panel p,
+.mp-players,
+.mp-room-code {
+  font-size: 13px;
+}
+
+.mp-local-player,
+.mp-players {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.mp-actions {
+  display: grid;
+  gap: 10px;
+}
+
+.mp-actions form {
+  display: grid;
+  grid-template-columns: minmax(96px, auto) minmax(120px, 1fr) auto;
+  align-items: end;
+  gap: 8px;
+}
+
+.mp-actions label {
+  font-size: 12px;
+  color: #cbd5e1;
+}
+
+.mp-actions input {
+  min-height: 34px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.72);
+  color: #f8fafc;
+  padding: 6px 8px;
+  letter-spacing: 0.08em;
+}
+
+.mp-panel button {
+  min-height: 34px;
+  border: 1px solid rgba(125, 211, 252, 0.55);
+  border-radius: 6px;
+  background: #0ea5e9;
+  color: #082f49;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.mp-panel button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.mp-panel .mp-secondary {
+  justify-self: start;
+  background: rgba(15, 23, 42, 0.2);
+  color: #e2e8f0;
+}
+
+.mp-room-code strong {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 18px;
+  letter-spacing: 0.12em;
+}
+
+.mp-error {
+  color: #fecaca;
+}
+
+@media (max-width: 640px) {
+  .mp-panel-header,
+  .mp-actions form {
+    grid-template-columns: 1fr;
+  }
+
+  .mp-actions form {
+    align-items: stretch;
+  }
+}

--- a/src/multiplayer/peerConnection.ts
+++ b/src/multiplayer/peerConnection.ts
@@ -206,6 +206,10 @@ export class PeerRoomConnection<TMessage extends JsonObject = MultiplayerMessage
       throw new Error("Wiadomość multiplayer musi być obiektem JSON.");
     }
 
+    if (typeof parsed.type !== "string" || parsed.type.trim().length === 0) {
+      throw new Error("Wiadomość multiplayer musi mieć typ.");
+    }
+
     return parsed as TMessage;
   }
 

--- a/src/multiplayer/useMultiplayerLobby.ts
+++ b/src/multiplayer/useMultiplayerLobby.ts
@@ -7,6 +7,7 @@ import type { LocalMultiplayerPlayer, RemotePlayer } from "./gameSession.types";
 import {
   type AnyMultiplayerMessage,
   type BaseMultiplayerMessage,
+  type PlayerHelloMessage,
   type PlayerProfile,
   isPlayerHelloMessage,
   sendMessage as sendTypedMessage,
@@ -74,11 +75,14 @@ export function useMultiplayerLobby<TGameMessage extends BaseMultiplayerMessage 
   );
 
   const sendHello = useCallback(() => {
-    return sendTypedMessage(room.send, {
+    const helloMessage: PlayerHelloMessage = {
       type: "player:hello",
       senderId: localPlayer.id,
+      sentAt: Date.now(),
       player: toPlayerProfile(localPlayer),
-    });
+    };
+
+    return room.send(helloMessage);
   }, [localPlayer, room.send]);
 
   useEffect(() => {
@@ -170,4 +174,4 @@ function createLocalPlayerId(): string {
   return `player-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-export type LobbyGameMessage<TType extends string, TPayload extends JsonObject = JsonObject> = BaseMultiplayerMessage<TType> & TPayload;
+export type LobbyGameMessage<TType extends string, TPayload = JsonObject> = BaseMultiplayerMessage<TType> & TPayload;

--- a/src/multiplayer/useMultiplayerLobby.ts
+++ b/src/multiplayer/useMultiplayerLobby.ts
@@ -7,6 +7,7 @@ import type { LocalMultiplayerPlayer, RemotePlayer } from "./gameSession.types";
 import {
   type AnyMultiplayerMessage,
   type BaseMultiplayerMessage,
+  type OutgoingMultiplayerMessage,
   type PlayerHelloMessage,
   type PlayerProfile,
   isPlayerHelloMessage,
@@ -31,7 +32,7 @@ export type UseMultiplayerLobbyResult<TGameMessage extends BaseMultiplayerMessag
   host: () => Promise<PeerRoomSnapshot>;
   join: (roomCode: string) => Promise<PeerRoomSnapshot>;
   close: () => void;
-  sendMessage: (message: Omit<TGameMessage, "sentAt" | "senderId"> & Partial<Pick<TGameMessage, "sentAt" | "senderId">>) => boolean;
+  sendMessage: (message: OutgoingMultiplayerMessage<TGameMessage>) => boolean;
 };
 
 export function useMultiplayerLobby<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>(
@@ -115,7 +116,7 @@ export function useMultiplayerLobby<TGameMessage extends BaseMultiplayerMessage 
   }, [room]);
 
   const sendMessage = useCallback(
-    (message: Omit<TGameMessage, "sentAt" | "senderId"> & Partial<Pick<TGameMessage, "sentAt" | "senderId">>) => {
+    (message: OutgoingMultiplayerMessage<TGameMessage>) => {
       return sendTypedMessage(room.send as (value: TGameMessage) => boolean, {
         ...message,
         senderId: message.senderId ?? localPlayer.id,

--- a/src/multiplayer/useMultiplayerLobby.ts
+++ b/src/multiplayer/useMultiplayerLobby.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { loadPlayerSettings, subscribePlayerSettings } from "@/settings/player/playerSettings.storage";
+import type { PlayerSettings } from "@/settings/player/playerSettings.types";
+import { usePeerRoom } from "./usePeerRoom";
+import type { JsonObject, MultiplayerConnectionStatus, MultiplayerRole, PeerRoomSnapshot } from "./multiplayer.types";
+import type { LocalMultiplayerPlayer, RemotePlayer } from "./gameSession.types";
+import {
+  type AnyMultiplayerMessage,
+  type BaseMultiplayerMessage,
+  type PlayerProfile,
+  isPlayerHelloMessage,
+  sendMessage as sendTypedMessage,
+} from "./messages";
+
+export type MultiplayerLobbyStatus = MultiplayerConnectionStatus;
+
+export type UseMultiplayerLobbyOptions<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  onGameMessage?: (message: TGameMessage) => void;
+};
+
+export type UseMultiplayerLobbyResult<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  status: MultiplayerLobbyStatus;
+  role: MultiplayerRole | null;
+  roomCode: string | null;
+  error: PeerRoomSnapshot["error"];
+  localPlayer: LocalMultiplayerPlayer;
+  remotePlayers: RemotePlayer[];
+  opponent: RemotePlayer | null;
+  lastMessage: TGameMessage | null;
+  host: () => Promise<PeerRoomSnapshot>;
+  join: (roomCode: string) => Promise<PeerRoomSnapshot>;
+  close: () => void;
+  sendMessage: (message: Omit<TGameMessage, "sentAt" | "senderId"> & Partial<Pick<TGameMessage, "sentAt" | "senderId">>) => boolean;
+};
+
+export function useMultiplayerLobby<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>(
+  options: UseMultiplayerLobbyOptions<TGameMessage> = {}
+): UseMultiplayerLobbyResult<TGameMessage> {
+  const playerIdRef = useRef(createLocalPlayerId());
+  const onGameMessageRef = useRef(options.onGameMessage);
+  const [playerSettings, setPlayerSettings] = useState<PlayerSettings>(() => loadPlayerSettings());
+  const [remotePlayers, setRemotePlayers] = useState<RemotePlayer[]>([]);
+  const [lastGameMessage, setLastGameMessage] = useState<TGameMessage | null>(null);
+
+  useEffect(() => {
+    onGameMessageRef.current = options.onGameMessage;
+  }, [options.onGameMessage]);
+
+  useEffect(() => subscribePlayerSettings(setPlayerSettings), []);
+
+  const handleIncomingMessage = useCallback((message: AnyMultiplayerMessage) => {
+    if (isPlayerHelloMessage(message)) {
+      const remote = toRemotePlayer(message.player);
+      setRemotePlayers((players) => upsertRemotePlayer(players, remote));
+      return;
+    }
+
+    const gameMessage = message as TGameMessage;
+    setLastGameMessage(gameMessage);
+    onGameMessageRef.current?.(gameMessage);
+  }, []);
+
+  const room = usePeerRoom<AnyMultiplayerMessage>({ onMessage: handleIncomingMessage });
+
+  const localPlayer = useMemo<LocalMultiplayerPlayer>(
+    () => ({
+      id: playerIdRef.current,
+      name: playerSettings.name,
+      color: playerSettings.color,
+      emoji: playerSettings.emoji,
+      role: room.role,
+    }),
+    [playerSettings, room.role]
+  );
+
+  const sendHello = useCallback(() => {
+    return sendTypedMessage(room.send, {
+      type: "player:hello",
+      senderId: localPlayer.id,
+      player: toPlayerProfile(localPlayer),
+    });
+  }, [localPlayer, room.send]);
+
+  useEffect(() => {
+    if (room.status === "connected") {
+      sendHello();
+      return;
+    }
+
+    if (room.status === "idle" || room.status === "joining" || room.status === "hosting" || room.status === "closed") {
+      setRemotePlayers([]);
+    }
+  }, [room.status, sendHello]);
+
+  const host = useCallback(async () => {
+    setRemotePlayers([]);
+    return room.host();
+  }, [room]);
+
+  const join = useCallback(
+    async (roomCode: string) => {
+      setRemotePlayers([]);
+      return room.join(roomCode);
+    },
+    [room]
+  );
+
+  const close = useCallback(() => {
+    setRemotePlayers([]);
+    room.close();
+  }, [room]);
+
+  const sendMessage = useCallback(
+    (message: Omit<TGameMessage, "sentAt" | "senderId"> & Partial<Pick<TGameMessage, "sentAt" | "senderId">>) => {
+      return sendTypedMessage(room.send as (value: TGameMessage) => boolean, {
+        ...message,
+        senderId: message.senderId ?? localPlayer.id,
+      } as Omit<TGameMessage, "sentAt"> & Partial<Pick<TGameMessage, "sentAt">>);
+    },
+    [localPlayer.id, room.send]
+  );
+
+  return {
+    status: room.status,
+    role: room.role,
+    roomCode: room.roomCode,
+    error: room.error,
+    localPlayer,
+    remotePlayers,
+    opponent: remotePlayers[0] ?? null,
+    lastMessage: lastGameMessage,
+    host,
+    join,
+    close,
+    sendMessage,
+  };
+}
+
+function toPlayerProfile(player: LocalMultiplayerPlayer): PlayerProfile {
+  return {
+    id: player.id,
+    name: player.name,
+    color: player.color,
+    emoji: player.emoji,
+  };
+}
+
+function toRemotePlayer(player: PlayerProfile): RemotePlayer {
+  return {
+    ...player,
+    peerId: player.id,
+    connectedAt: Date.now(),
+  };
+}
+
+function upsertRemotePlayer(players: RemotePlayer[], player: RemotePlayer): RemotePlayer[] {
+  const existingIndex = players.findIndex((item) => item.id === player.id);
+  if (existingIndex < 0) return [...players, player];
+
+  const next = players.slice();
+  next[existingIndex] = { ...next[existingIndex], ...player };
+  return next;
+}
+
+function createLocalPlayerId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `player-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export type LobbyGameMessage<TType extends string, TPayload extends JsonObject = JsonObject> = BaseMultiplayerMessage<TType> & TPayload;

--- a/src/multiplayer/usePeerClientRoom.ts
+++ b/src/multiplayer/usePeerClientRoom.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Peer, { type DataConnection } from "peerjs";
+import { isValidRoomCode, normalizeRoomCode } from "./peerConnection";
+import type { MultiplayerConnectionError } from "./multiplayer.types";
+import {
+  type BaseMultiplayerMessage,
+  isRoomPlayersMessage,
+  parseMultiplayerMessage,
+  sendMessage as sendTypedMessage,
+} from "./messages";
+import type { HostClientRoomEvent, HostClientRoomOptions, HostClientRoomStatus, RemotePlayer } from "./hostClientRoom.types";
+
+export type UsePeerClientRoomResult<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  status: HostClientRoomStatus;
+  roomCode: string | null;
+  localPeerId: string | null;
+  players: RemotePlayer[];
+  lastEvent: HostClientRoomEvent<TMessage> | null;
+  error: MultiplayerConnectionError | null;
+  join: (roomCode: string) => Promise<string | null>;
+  close: () => void;
+  send: (message: TMessage) => boolean;
+};
+
+export function usePeerClientRoom<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>(
+  options: HostClientRoomOptions<TMessage> = {}
+): UsePeerClientRoomResult<TMessage> {
+  const peerRef = useRef<Peer | null>(null);
+  const connectionRef = useRef<DataConnection | null>(null);
+  const onEventRef = useRef(options.onEvent);
+  const [status, setStatus] = useState<HostClientRoomStatus>("idle");
+  const [roomCode, setRoomCode] = useState<string | null>(null);
+  const [localPeerId, setLocalPeerId] = useState<string | null>(null);
+  const [players, setPlayers] = useState<RemotePlayer[]>([]);
+  const [lastEvent, setLastEvent] = useState<HostClientRoomEvent<TMessage> | null>(null);
+  const [error, setError] = useState<MultiplayerConnectionError | null>(null);
+
+  useEffect(() => {
+    onEventRef.current = options.onEvent;
+  }, [options.onEvent]);
+
+  const emit = useCallback((event: HostClientRoomEvent<TMessage>) => {
+    setLastEvent(event);
+    onEventRef.current?.(event);
+  }, []);
+
+  const close = useCallback(() => {
+    if (connectionRef.current?.open) {
+      connectionRef.current.close();
+    }
+    connectionRef.current = null;
+
+    if (peerRef.current && !peerRef.current.destroyed) {
+      peerRef.current.destroy();
+    }
+    peerRef.current = null;
+    setPlayers([]);
+    setRoomCode(null);
+    setLocalPeerId(null);
+    setStatus("closed");
+    emit({ type: "room-closed" });
+  }, [emit]);
+
+  const bindConnection = useCallback(
+    (connection: DataConnection) => {
+      connectionRef.current = connection;
+
+      connection.on("open", () => {
+        setStatus("connected");
+        if (options.localPlayer) {
+          sendTypedMessage(sendRaw.bind(null, connection), {
+            type: "player:hello",
+            senderId: options.localPlayer.id,
+            player: options.localPlayer,
+          });
+        }
+      });
+
+      connection.on("data", (data: unknown) => {
+        const message = parseMultiplayerMessage<TMessage>(data);
+        if (!message) {
+          const invalidError = { message: "Odebrano nieprawidłową wiadomość multiplayer." };
+          setError(invalidError);
+          emit({ type: "error", error: invalidError });
+          return;
+        }
+
+        if (isRoomPlayersMessage(message)) {
+          setPlayers(
+            message.players.map((player) => ({
+              ...player,
+              peerId: player.id,
+              connectedAt: Date.now(),
+            }))
+          );
+          return;
+        }
+
+        emit({ type: "message-received", peerId: connection.peer, message });
+      });
+
+      connection.on("close", () => {
+        setStatus("closed");
+        emit({ type: "room-closed" });
+      });
+
+      connection.on("error", (cause: unknown) => {
+        const connectionError = { message: "Wystąpił błąd połączenia z hostem.", cause };
+        setError(connectionError);
+        setStatus("error");
+        emit({ type: "error", error: connectionError });
+      });
+    },
+    [emit, options.localPlayer]
+  );
+
+  const join = useCallback(
+    async (requestedRoomCode: string): Promise<string | null> => {
+      const normalizedCode = normalizeRoomCode(requestedRoomCode);
+      if (!isValidRoomCode(normalizedCode)) {
+        const invalidError = { message: "Kod pokoju jest nieprawidłowy." };
+        setError(invalidError);
+        setStatus("error");
+        emit({ type: "error", error: invalidError });
+        return null;
+      }
+
+      close();
+      setStatus("joining");
+      setRoomCode(normalizedCode);
+      setError(null);
+
+      const peer = new Peer();
+      peerRef.current = peer;
+      peer.on("open", (id) => {
+        setLocalPeerId(id);
+        const connection = peer.connect(normalizedCode, { reliable: true, serialization: "json" });
+        bindConnection(connection);
+      });
+      peer.on("error", (cause: unknown) => {
+        const peerError = { message: "Nie udało się dołączyć do pokoju multiplayer.", cause };
+        setError(peerError);
+        setStatus("error");
+        emit({ type: "error", error: peerError });
+      });
+
+      return normalizedCode;
+    },
+    [bindConnection, close, emit]
+  );
+
+  const send = useCallback((message: TMessage): boolean => {
+    if (!connectionRef.current) return false;
+    return sendRaw(connectionRef.current, message);
+  }, []);
+
+  useEffect(() => close, [close]);
+
+  return {
+    status,
+    roomCode,
+    localPeerId,
+    players,
+    lastEvent,
+    error,
+    join,
+    close,
+    send,
+  };
+}
+
+function sendRaw(connection: DataConnection, message: BaseMultiplayerMessage): boolean {
+  if (!connection.open) return false;
+  connection.send(JSON.stringify(message));
+  return true;
+}

--- a/src/multiplayer/usePeerClientRoom.ts
+++ b/src/multiplayer/usePeerClientRoom.ts
@@ -2,12 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Peer, { type DataConnection } from "peerjs";
 import { isValidRoomCode, normalizeRoomCode } from "./peerConnection";
 import type { MultiplayerConnectionError } from "./multiplayer.types";
-import {
-  type BaseMultiplayerMessage,
-  isRoomPlayersMessage,
-  parseMultiplayerMessage,
-  sendMessage as sendTypedMessage,
-} from "./messages";
+import { type BaseMultiplayerMessage, type PlayerHelloMessage, isRoomPlayersMessage, parseMultiplayerMessage } from "./messages";
 import type { HostClientRoomEvent, HostClientRoomOptions, HostClientRoomStatus, RemotePlayer } from "./hostClientRoom.types";
 
 export type UsePeerClientRoomResult<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
@@ -68,11 +63,13 @@ export function usePeerClientRoom<TMessage extends BaseMultiplayerMessage = Base
       connection.on("open", () => {
         setStatus("connected");
         if (options.localPlayer) {
-          sendTypedMessage(sendRaw.bind(null, connection), {
+          const helloMessage: PlayerHelloMessage = {
             type: "player:hello",
             senderId: options.localPlayer.id,
+            sentAt: Date.now(),
             player: options.localPlayer,
-          });
+          };
+          sendRaw(connection, helloMessage);
         }
       });
 

--- a/src/multiplayer/usePeerHostRoom.ts
+++ b/src/multiplayer/usePeerHostRoom.ts
@@ -6,9 +6,9 @@ import {
   type BaseMultiplayerMessage,
   type PlayerHelloMessage,
   type PlayerProfile,
+  type RoomPlayersMessage,
   isPlayerHelloMessage,
   parseMultiplayerMessage,
-  sendMessage as sendTypedMessage,
 } from "./messages";
 import type { HostClientRoomEvent, HostClientRoomOptions, HostClientRoomStatus, RemotePlayer } from "./hostClientRoom.types";
 
@@ -50,12 +50,12 @@ export function usePeerHostRoom<TMessage extends BaseMultiplayerMessage = BaseMu
 
   const publishPlayers = useCallback(() => {
     const remotePlayers = Array.from(playersRef.current.values());
-    const allPlayers = options.localPlayer ? [options.localPlayer, ...remotePlayers] : remotePlayers;
-    const message = {
+    const allPlayers: PlayerProfile[] = options.localPlayer ? [options.localPlayer, ...remotePlayers] : remotePlayers;
+    const message: RoomPlayersMessage = {
       type: "room:players",
       senderId: options.localPlayer?.id,
       players: allPlayers,
-    } as Parameters<typeof sendTypedMessage>[1] & { players: PlayerProfile[] };
+    };
 
     for (const connection of connectionsRef.current.values()) {
       sendRaw(connection, message);

--- a/src/multiplayer/usePeerHostRoom.ts
+++ b/src/multiplayer/usePeerHostRoom.ts
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Peer, { type DataConnection } from "peerjs";
+import { createRoomCode, isValidRoomCode, normalizeRoomCode } from "./peerConnection";
+import type { MultiplayerConnectionError } from "./multiplayer.types";
+import {
+  type BaseMultiplayerMessage,
+  type PlayerHelloMessage,
+  type PlayerProfile,
+  isPlayerHelloMessage,
+  parseMultiplayerMessage,
+  sendMessage as sendTypedMessage,
+} from "./messages";
+import type { HostClientRoomEvent, HostClientRoomOptions, HostClientRoomStatus, RemotePlayer } from "./hostClientRoom.types";
+
+export type UsePeerHostRoomResult<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  status: HostClientRoomStatus;
+  roomCode: string | null;
+  localPeerId: string | null;
+  players: RemotePlayer[];
+  lastEvent: HostClientRoomEvent<TMessage> | null;
+  error: MultiplayerConnectionError | null;
+  host: (roomCode?: string) => Promise<string | null>;
+  close: () => void;
+  broadcast: (message: TMessage) => boolean;
+  sendTo: (peerId: string, message: TMessage) => boolean;
+};
+
+export function usePeerHostRoom<TMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>(
+  options: HostClientRoomOptions<TMessage> = {}
+): UsePeerHostRoomResult<TMessage> {
+  const peerRef = useRef<Peer | null>(null);
+  const connectionsRef = useRef(new Map<string, DataConnection>());
+  const playersRef = useRef(new Map<string, RemotePlayer>());
+  const onEventRef = useRef(options.onEvent);
+  const [status, setStatus] = useState<HostClientRoomStatus>("idle");
+  const [roomCode, setRoomCode] = useState<string | null>(null);
+  const [localPeerId, setLocalPeerId] = useState<string | null>(null);
+  const [players, setPlayers] = useState<RemotePlayer[]>([]);
+  const [lastEvent, setLastEvent] = useState<HostClientRoomEvent<TMessage> | null>(null);
+  const [error, setError] = useState<MultiplayerConnectionError | null>(null);
+
+  useEffect(() => {
+    onEventRef.current = options.onEvent;
+  }, [options.onEvent]);
+
+  const emit = useCallback((event: HostClientRoomEvent<TMessage>) => {
+    setLastEvent(event);
+    onEventRef.current?.(event);
+  }, []);
+
+  const publishPlayers = useCallback(() => {
+    const remotePlayers = Array.from(playersRef.current.values());
+    const allPlayers = options.localPlayer ? [options.localPlayer, ...remotePlayers] : remotePlayers;
+    const message = {
+      type: "room:players",
+      senderId: options.localPlayer?.id,
+      players: allPlayers,
+    } as Parameters<typeof sendTypedMessage>[1] & { players: PlayerProfile[] };
+
+    for (const connection of connectionsRef.current.values()) {
+      sendRaw(connection, message);
+    }
+  }, [options.localPlayer]);
+
+  const syncPlayers = useCallback(
+    (next: Map<string, RemotePlayer>) => {
+      playersRef.current = next;
+      setPlayers(Array.from(next.values()));
+      publishPlayers();
+    },
+    [publishPlayers]
+  );
+
+  const removePlayer = useCallback(
+    (peerId: string) => {
+      const player = playersRef.current.get(peerId);
+      connectionsRef.current.delete(peerId);
+      if (!player) return;
+
+      const next = new Map(playersRef.current);
+      next.delete(peerId);
+      syncPlayers(next);
+      emit({ type: "player-left", player });
+    },
+    [emit, syncPlayers]
+  );
+
+  const bindConnection = useCallback(
+    (connection: DataConnection) => {
+      connectionsRef.current.set(connection.peer, connection);
+
+      connection.on("open", () => {
+        const fallbackPlayer: RemotePlayer = {
+          id: connection.peer,
+          peerId: connection.peer,
+          name: `Gracz ${playersRef.current.size + 1}`,
+          color: "#38bdf8",
+          emoji: "🙂",
+          connectedAt: Date.now(),
+        };
+        const next = new Map(playersRef.current);
+        next.set(connection.peer, fallbackPlayer);
+        syncPlayers(next);
+        emit({ type: "player-joined", player: fallbackPlayer });
+      });
+
+      connection.on("data", (data: unknown) => {
+        const message = parseMultiplayerMessage<TMessage | PlayerHelloMessage>(data);
+        if (!message) {
+          const invalidError = { message: "Odebrano nieprawidłową wiadomość multiplayer." };
+          setError(invalidError);
+          emit({ type: "error", error: invalidError });
+          return;
+        }
+
+        if (isPlayerHelloMessage(message)) {
+          const player: RemotePlayer = {
+            ...message.player,
+            peerId: connection.peer,
+            connectedAt: playersRef.current.get(connection.peer)?.connectedAt ?? Date.now(),
+          };
+          const next = new Map(playersRef.current);
+          next.set(connection.peer, player);
+          syncPlayers(next);
+          emit({ type: "player-joined", player });
+          return;
+        }
+
+        emit({ type: "message-received", peerId: connection.peer, message: message as TMessage });
+      });
+
+      connection.on("close", () => removePlayer(connection.peer));
+      connection.on("error", (cause: unknown) => {
+        const connectionError = { message: "Wystąpił błąd połączenia z graczem.", cause };
+        setError(connectionError);
+        emit({ type: "error", error: connectionError });
+      });
+    },
+    [emit, removePlayer, syncPlayers]
+  );
+
+  const close = useCallback(() => {
+    for (const connection of connectionsRef.current.values()) {
+      if (connection.open) connection.close();
+    }
+    connectionsRef.current.clear();
+    playersRef.current.clear();
+    setPlayers([]);
+
+    if (peerRef.current && !peerRef.current.destroyed) {
+      peerRef.current.destroy();
+    }
+    peerRef.current = null;
+    setRoomCode(null);
+    setLocalPeerId(null);
+    setStatus("closed");
+    emit({ type: "room-closed" });
+  }, [emit]);
+
+  const host = useCallback(
+    async (requestedRoomCode = createRoomCode()): Promise<string | null> => {
+      const normalizedCode = normalizeRoomCode(requestedRoomCode);
+      if (!isValidRoomCode(normalizedCode)) {
+        const invalidError = { message: "Kod pokoju jest nieprawidłowy." };
+        setError(invalidError);
+        setStatus("error");
+        emit({ type: "error", error: invalidError });
+        return null;
+      }
+
+      close();
+      setStatus("hosting");
+      setRoomCode(normalizedCode);
+      setError(null);
+
+      const peer = new Peer(normalizedCode);
+      peerRef.current = peer;
+      peer.on("connection", bindConnection);
+      peer.on("open", (id) => {
+        setLocalPeerId(id);
+        setStatus("connected");
+      });
+      peer.on("close", () => {
+        setStatus("closed");
+        emit({ type: "room-closed" });
+      });
+      peer.on("error", (cause: unknown) => {
+        const peerError = { message: "Nie udało się utworzyć pokoju multiplayer.", cause };
+        setError(peerError);
+        setStatus("error");
+        emit({ type: "error", error: peerError });
+      });
+
+      return normalizedCode;
+    },
+    [bindConnection, close, emit]
+  );
+
+  const sendTo = useCallback((peerId: string, message: TMessage): boolean => {
+    const connection = connectionsRef.current.get(peerId);
+    if (!connection) return false;
+    return sendRaw(connection, message);
+  }, []);
+
+  const broadcast = useCallback((message: TMessage): boolean => {
+    let sent = false;
+    for (const connection of connectionsRef.current.values()) {
+      sent = sendRaw(connection, message) || sent;
+    }
+    return sent;
+  }, []);
+
+  useEffect(() => close, [close]);
+
+  return {
+    status,
+    roomCode,
+    localPeerId,
+    players,
+    lastEvent,
+    error,
+    host,
+    close,
+    broadcast,
+    sendTo,
+  };
+}
+
+function sendRaw(connection: DataConnection, message: BaseMultiplayerMessage): boolean {
+  if (!connection.open) return false;
+  connection.send(JSON.stringify(message));
+  return true;
+}

--- a/src/window/registry.ts
+++ b/src/window/registry.ts
@@ -18,6 +18,17 @@ export type WindowDefaults = {
 // Registry maps well-known window ids to their default metadata and content loader.
 // Desktop can use this to open windows without hardcoding sizes/positions everywhere.
 export const WindowRegistry: Record<string, WindowDefaults> = {
+  tictactoe: {
+    id: "tictactoe",
+    title: "Kółko i Krzyżyk",
+    width: 620,
+    height: 760,
+    minWidth: 420,
+    minHeight: 620,
+    x: 100,
+    y: 70,
+    loader: () => import("@/games/tictactoe/TicTacToeGame"),
+  },
   snake: {
     id: "snake",
     title: "Wąż",


### PR DESCRIPTION
## Summary

Implements issues #130, #131 and #132.

- Adds a typed multiplayer message protocol with common messages: `player:hello`, `game:reset`, `game:ready`, `game:error`, plus extension support for game-specific messages.
- Adds a reusable `useMultiplayerLobby` hook and `MultiplayerPanel` for 1v1 host/join flows without `prompt()`.
- Adds host-client room hooks for multi-player games: `usePeerHostRoom` and `usePeerClientRoom`, including player lists, broadcast, sendTo, disconnect handling, and neutral events.
- Adds a multiplayer Tic Tac Toe implementation as the first consumer of the shared panel.
- Registers Tic Tac Toe in the desktop window registry and enables the shortcut.

## Notes

- Host starts as `X` in Tic Tac Toe, guest starts second as `O`, matching the legacy host-first model.
- Incoming messages are minimally validated before game code receives them.
- Game components do not parse raw DataChannel payloads directly.

## Validation

- Reviewed the GitHub compare for the branch against `main`.
- Performed a manual type/API review of the new multiplayer protocol, lobby hook, host-client hooks, and Tic Tac Toe usage.
- Could not run `npm run build` locally because direct repository checkout from GitHub is blocked in this environment.