### PR TITLE
fix: normalize Vite base path handling (#121)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,10 @@ import react from "@vitejs/plugin-react";
 
 const srcPath = new URL("./src", import.meta.url).pathname;
 
+declare const process: {
+  env?: Record<string, string | undefined>;
+};
+
 const normalizeBasePath = (value?: string): string => {
   if (!value || value.trim().length === 0) {
     return "/";
@@ -13,7 +17,7 @@ const normalizeBasePath = (value?: string): string => {
   return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
 };
 
-const base = normalizeBasePath(process.env.VITE_BASE_PATH);
+const base = normalizeBasePath(process.env?.VITE_BASE_PATH);
 
 export default defineConfig({
   plugins: [react()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,23 @@
-﻿import { defineConfig } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// Use URL-based alias to avoid relying on Node globals/types in ESM
 const srcPath = new URL("./src", import.meta.url).pathname;
 
-// Determine base path for GitHub Pages deployments.
-// Avoid Node types by reading from import.meta.env at build-time.
-// The workflow sets VITE_BASE_PATH env which Vite exposes as import.meta.env.VITE_BASE_PATH.
-const baseFromEnv = (import.meta as any).env?.VITE_BASE_PATH as string | undefined;
-const base = baseFromEnv && baseFromEnv.trim().length > 0 ? baseFromEnv : "/";
+const normalizeBasePath = (value?: string): string => {
+  if (!value || value.trim().length === 0) {
+    return "/";
+  }
+
+  const trimmed = value.trim();
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
+};
+
+const base = normalizeBasePath(process.env.VITE_BASE_PATH);
 
 export default defineConfig({
   plugins: [react()],
-  // Force correct base for GitHub Pages project site:
-  // https://pawelwielga.github.io/desktop-games/
-  // This avoids absolute /assets/... pointing to the root user page.
-  base: "/desktop-games/",
+  base,
   resolve: {
     alias: {
       "@": srcPath,


### PR DESCRIPTION
Closes #121

Changes:
- remove dead base path logic
- use VITE_BASE_PATH consistently
- normalize leading/trailing slashes
- keep local builds on '/' fallback
- align Vite config with GitHub Pages workflow