### PR TITLE
[codex] Stabilize WindowManager state flow

### DIFF
--- a/src/window/WindowManager.tsx
+++ b/src/window/WindowManager.tsx
@@ -78,14 +78,29 @@ export function useWindowManager(): Ctx {
   return ctx;
 }
 
+function hasPositionPatch(patch: Partial<WindowState>): boolean {
+  return "x" in patch || "y" in patch;
+}
+
+function persistWindowPosition(id: string, x: number, y: number): void {
+  try {
+    localStorage.setItem(`wm:pos:${id}`, JSON.stringify({ x, y }));
+  } catch {}
+}
+
 /**
  * Provider component for window management.
  * Keep as a stable named function export for Fast Refresh.
  */
 export function WindowManager({ children }: { children: React.ReactNode }): React.ReactElement {
   const [windows, setWindows] = useState<WindowState[]>([]);
+  const windowsRef = useRef<WindowState[]>([]);
   const zCounter = useRef(1500);
   const { settings } = useSettings();
+
+  useEffect(() => {
+    windowsRef.current = windows;
+  }, [windows]);
 
   const open = useCallback((spec: WindowSpec) => {
     setWindows((prev) => {
@@ -206,6 +221,21 @@ export function WindowManager({ children }: { children: React.ReactNode }): Reac
     );
   }, []);
 
+  const patchWindow = useCallback((id: string, patch: Partial<WindowState>) => {
+    if (settings.windowDrag.persistPositions && hasPositionPatch(patch)) {
+      const current = windowsRef.current.find((w) => w.id === id);
+      const nextX = typeof patch.x === "number" ? patch.x : current?.x;
+      const nextY = typeof patch.y === "number" ? patch.y : current?.y;
+      if (typeof nextX === "number" && typeof nextY === "number") {
+        persistWindowPosition(id, nextX, nextY);
+      }
+    }
+
+    setWindows((prev) =>
+      prev.map((w) => (w.id === id ? { ...w, ...patch } : w))
+    );
+  }, [settings.windowDrag.persistPositions]);
+
   const ctx = useMemo<Ctx>(
     () => ({
       windows,
@@ -281,35 +311,7 @@ export function WindowManager({ children }: { children: React.ReactNode }): Reac
             onMinimize={minimize}
             onMaximize={maximizeToggle}
             onFocus={focus}
-            onPatch={(patch) => {
-              // DIAG: log every position patch
-              if ("x" in patch || "y" in patch) {
-                // eslint-disable-next-line no-console
-                console.debug("[WM][patch] id=%s ->", w.id, { x: patch.x, y: patch.y });
-              }
-              setWindows((prev) =>
-                prev.map((x) => (x.id === w.id ? { ...x, ...patch } : x))
-              );
-
-              // Persist position if enabled (always attempt; storage errors ignored)
-              try {
-                if (("x" in patch || "y" in patch)) {
-                  const key = `wm:pos:${w.id}`;
-                  const nx = ("x" in patch && typeof patch.x === "number") ? patch.x : w.x;
-                  const ny = ("y" in patch && typeof patch.y === "number") ? patch.y : w.y;
-                  localStorage.setItem(key, JSON.stringify({ x: nx, y: ny }));
-                }
-              } catch {}
-
-              // Force immediate style sync for the active window to bypass any render delay
-              if (("x" in patch || "y" in patch)) {
-                const el = document.querySelector<HTMLElement>(`.window[aria-label="${w.title}"]`);
-                if (el) {
-                  if (typeof patch.x === "number") el.style.left = `${patch.x}px`;
-                  if (typeof patch.y === "number") el.style.top = `${patch.y}px`;
-                }
-              }
-            }}
+            onPatch={(patch) => patchWindow(w.id, patch)}
           />
         ))}
       </div>
@@ -399,8 +401,8 @@ function WindowFrame(props: {
         tabIndex={0}
         aria-roledescription="Window title bar. Drag to move, double click to maximize."
         title="Drag to move, double click to maximize"
-        onPointerDown={(e) => {
-          // Ensure window is focused before drag so z-index and style sync apply to the active window
+        onPointerDown={() => {
+          // Ensure window is focused before drag so z-index applies to the active window
           props.onFocus(w.id);
         }}
       >

--- a/src/window/hooks/useWindowDrag.ts
+++ b/src/window/hooks/useWindowDrag.ts
@@ -68,11 +68,9 @@ export function useWindowDrag(
 
     // Snap to other windows (query by class). Use bounding rects in CSS pixels.
     const rectA = { x: sx, y: sy, w, h };
-    const currentLabel = document.activeElement?.getAttribute?.("aria-label");
     const others = Array.from(document.querySelectorAll<HTMLElement>(".window"));
 
     for (const el of others) {
-      // skip elements without geometry
       const r = el.getBoundingClientRect();
       const edges = {
         left: r.left,
@@ -128,36 +126,7 @@ export function useWindowDrag(
     if (typeof (e as any).preventDefault === "function") (e as any).preventDefault();
 
     startPoint.current = { x: e.clientX, y: e.clientY };
-
-    // Determine the live on-screen starting position to avoid snap-back between drags.
-    // Prefer inline left/top (sync writes in WindowManager onPatch), else computed rect, else state fallback.
-    let liveX = st.x;
-    let liveY = st.y;
-    try {
-      // Find the nearest .window element by traversing from header/content
-      const rootEl =
-        (opts?.headerEl?.closest?.(".window") as HTMLElement | null) ??
-        (opts?.contentEl?.closest?.(".window") as HTMLElement | null) ??
-        null;
-      if (rootEl) {
-        const inlineLeft = (rootEl.style && rootEl.style.left) ? parseFloat(rootEl.style.left) : NaN;
-        const inlineTop = (rootEl.style && rootEl.style.top) ? parseFloat(rootEl.style.top) : NaN;
-        if (Number.isFinite(inlineLeft) && Number.isFinite(inlineTop)) {
-          liveX = inlineLeft;
-          liveY = inlineTop;
-        } else {
-          // Fall back to bounding rect relative to viewport
-          const rect = rootEl.getBoundingClientRect();
-          // The window root container is fixed to the viewport; use rect.left/top directly.
-          liveX = rect.left;
-          liveY = rect.top;
-        }
-      }
-    } catch {
-      // ignore, keep state fallback
-    }
-
-    startPos.current = { x: liveX, y: liveY };
+    startPos.current = { x: st.x, y: st.y };
     dragActive.current = false;
 
     // Hold-to-drag support


### PR DESCRIPTION
## Summary
- Removes the temporary WindowManager debug logging from position patches.
- Removes direct DOM style synchronization through `aria-label` lookups.
- Makes drag start from the current React window state instead of reading inline DOM position.
- Keeps persisted drag positions working through the window patch flow.

## Review
- Self-reviewed the diff for the WindowManager and drag hook changes.
- Confirmed the PR diff is limited to `src/window/WindowManager.tsx` and `src/window/hooks/useWindowDrag.ts`.

## Validation
- Not run locally: this environment blocks cloning the repository through the terminal, so I could not run `npm run verify` against a full checkout.

Closes #122