### PR TITLE
feat: add reusable app registration contract

### DIFF
--- a/src/desktop/Desktop.tsx
+++ b/src/desktop/Desktop.tsx
@@ -1,49 +1,27 @@
 import React, { useMemo, useRef, useState, useEffect } from "react";
 import "./desktop.css";
 import { useWindowManager } from "@/window/WindowManager";
-import { getWindowDefaults } from "@/window/registry";
+import { getAppRegistration, getDesktopApps, getWindowDefaults } from "@/window/registry";
 import ProgressiveImage from "@/components/ProgressiveImage";
-
-type Shortcut = {
-  id: string;
-  icon: string; // emoji
-  label: string;
-  implemented?: boolean;
-};
 
 export default function Desktop(): React.ReactElement {
   const { open, handles, focus } = useWindowManager();
 
-  // Centralize shortcut definitions; labels can later be i18n'ed
-  const shortcuts: Shortcut[] = useMemo(
-    () => [
-      { id: "tictactoe", icon: "🔢", label: "Kółko i Krzyżyk", implemented: true },
-      { id: "memo", icon: "🧠", label: "Memo", implemented: false },
-      { id: "snake", icon: "🐍", label: "Wąż", implemented: true },
-      { id: "rps", icon: "✊", label: "Kamień Papier Nożyce", implemented: false },
-      { id: "minesweeper", icon: "🚩", label: "Saper", implemented: true },
-      { id: "tetris", icon: "🧱", label: "Tetris", implemented: false },
-      { id: "connect4", icon: "🟡", label: "Connect 4", implemented: false },
-      { id: "pong", icon: "🏓", label: "Pong", implemented: false },
-      { id: "cards", icon: "🃏", label: "Ewolucja", implemented: false },
-      { id: "calc", icon: "🖩", label: "Catculator", implemented: false },
-      // Settings panel is implemented (modal)
-      { id: "settings", icon: "⚙️", label: "Ustawienia", implemented: true },
-    ],
-    []
-  );
-
-  const visibleShortcuts = shortcuts.filter((s) => s.implemented);
+  const visibleShortcuts = useMemo(() => getDesktopApps(), []);
 
   const [showSettings, setShowSettings] = useState(false);
 
   const handleOpenById = async (id: string): Promise<void> => {
-    if (id === "settings") {
-      setShowSettings(true);
+    const app = getAppRegistration(id);
+    if (!app?.implemented) return;
+
+    if (app.kind === "system") {
+      if (app.id === "settings") setShowSettings(true);
       return;
     }
+
     const def = getWindowDefaults(id);
-    if (!def) return; // not yet implemented or unknown
+    if (!def) return;
     // Lazy-load component
     const mod = await def.loader();
     const Content = mod.default as React.ComponentType;
@@ -209,20 +187,14 @@ export default function Desktop(): React.ReactElement {
             key={s.id}
             className="desktop-icon"
             data-icon={s.icon}
-            title={s.label}
-            onClick={() => {
-              if (s.id === "settings") {
-                setShowSettings(true);
-              } else {
-                handleOpenById(s.id);
-              }
-            }}
+            title={s.title}
+            onClick={() => handleOpenById(s.id)}
             role="gridcell"
-            aria-label={s.label}
+            aria-label={s.title}
             tabIndex={i === activeIndex ? 0 : -1}
             onKeyDown={(e) => onIconKeyDown(e, i, s.id)}
           >
-            <div className="icon-label">{s.label}</div>
+            <div className="icon-label">{s.title}</div>
           </button>
         ))}
       </div>

--- a/src/window/registry.ts
+++ b/src/window/registry.ts
@@ -15,45 +15,159 @@ export type WindowDefaults = {
   loader: () => Promise<{ default: React.ComponentType<unknown> }>;
 };
 
-// Registry maps well-known window ids to their default metadata and content loader.
-// Desktop can use this to open windows without hardcoding sizes/positions everywhere.
-export const WindowRegistry: Record<string, WindowDefaults> = {
-  tictactoe: {
-    id: "tictactoe",
-    title: "Kółko i Krzyżyk",
-    width: 620,
-    height: 760,
-    minWidth: 420,
-    minHeight: 620,
-    x: 100,
-    y: 70,
-    loader: () => import("@/games/tictactoe/TicTacToeGame"),
-  },
-  snake: {
-    id: "snake",
-    title: "Wąż",
-    width: 820,
-    height: 680,
-    minWidth: 520,
-    minHeight: 640,
-    x: 120,
-    y: 80,
-    loader: () => import("@/games/snake/SnakeGame"),
-  },
-  minesweeper: {
-    id: "minesweeper",
-    title: "Saper",
-    width: 640,
-    height: 720,
-    minWidth: 520,
-    minHeight: 640,
-    x: 160,
-    y: 100,
-    loader: () => import("@/games/minesweeper/MinesweeperGame"),
-  },
+export type AppKind = "game" | "system";
+
+export type AppRegistration = {
+  id: string;
+  title: string;
+  icon: string;
+  kind: AppKind;
+  implemented: boolean;
+  showOnDesktop?: boolean;
+  window?: Omit<WindowDefaults, "id" | "title">;
 };
 
-// Helper to resolve defaults by id (useful for Desktop and other launchers)
+export type DesktopAppRegistration = AppRegistration & {
+  showOnDesktop: true;
+};
+
+export const AppRegistry: readonly AppRegistration[] = [
+  {
+    id: "tictactoe",
+    title: "Kółko i Krzyżyk",
+    icon: "🔢",
+    kind: "game",
+    implemented: true,
+    window: {
+      width: 620,
+      height: 760,
+      minWidth: 420,
+      minHeight: 620,
+      x: 100,
+      y: 70,
+      loader: () => import("@/games/tictactoe/TicTacToeGame"),
+    },
+  },
+  {
+    id: "memo",
+    title: "Memo",
+    icon: "🧠",
+    kind: "game",
+    implemented: false,
+  },
+  {
+    id: "snake",
+    title: "Wąż",
+    icon: "🐍",
+    kind: "game",
+    implemented: true,
+    window: {
+      width: 820,
+      height: 680,
+      minWidth: 520,
+      minHeight: 640,
+      x: 120,
+      y: 80,
+      loader: () => import("@/games/snake/SnakeGame"),
+    },
+  },
+  {
+    id: "rps",
+    title: "Kamień Papier Nożyce",
+    icon: "✊",
+    kind: "game",
+    implemented: false,
+  },
+  {
+    id: "minesweeper",
+    title: "Saper",
+    icon: "🚩",
+    kind: "game",
+    implemented: true,
+    window: {
+      width: 640,
+      height: 720,
+      minWidth: 520,
+      minHeight: 640,
+      x: 160,
+      y: 100,
+      loader: () => import("@/games/minesweeper/MinesweeperGame"),
+    },
+  },
+  {
+    id: "tetris",
+    title: "Tetris",
+    icon: "🧱",
+    kind: "game",
+    implemented: false,
+  },
+  {
+    id: "connect4",
+    title: "Connect 4",
+    icon: "🟡",
+    kind: "game",
+    implemented: false,
+  },
+  {
+    id: "pong",
+    title: "Pong",
+    icon: "🏓",
+    kind: "game",
+    implemented: false,
+  },
+  {
+    id: "cards",
+    title: "Ewolucja",
+    icon: "🃏",
+    kind: "game",
+    implemented: false,
+  },
+  {
+    id: "calc",
+    title: "Catculator",
+    icon: "🖩",
+    kind: "game",
+    implemented: false,
+  },
+  {
+    id: "settings",
+    title: "Ustawienia",
+    icon: "⚙️",
+    kind: "system",
+    implemented: true,
+  },
+] as const;
+
+export const WindowRegistry: Record<string, WindowDefaults> = AppRegistry.reduce<
+  Record<string, WindowDefaults>
+>((registry, app) => {
+  if (!app.window) return registry;
+
+  registry[app.id] = {
+    id: app.id,
+    title: app.title,
+    ...app.window,
+  };
+
+  return registry;
+}, {});
+
+export function getAppRegistration(id: string): AppRegistration | undefined {
+  return AppRegistry.find((app) => app.id === id);
+}
+
+export function getDesktopApps(options?: {
+  includeUnimplemented?: boolean;
+}): DesktopAppRegistration[] {
+  const includeUnimplemented = options?.includeUnimplemented ?? false;
+
+  return AppRegistry.filter((app): app is DesktopAppRegistration => {
+    const showOnDesktop = app.showOnDesktop ?? true;
+    return showOnDesktop && (includeUnimplemented || app.implemented);
+  }).map((app) => ({ ...app, showOnDesktop: true }));
+}
+
+// Helper to resolve defaults by id (useful for Desktop and other launchers).
 export function getWindowDefaults(id: string): WindowDefaults | undefined {
   return WindowRegistry[id];
 }


### PR DESCRIPTION
## Summary
- add a reusable app registration contract with metadata for games and system apps
- derive `WindowRegistry` from the shared app registry
- render desktop shortcuts from the same registry used to open game windows
- keep Settings separated as a system app while Snake, Minesweeper, and TicTacToe stay launchable through window defaults

Closes #123

## Verification
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run verify`