### PR TITLE
test: add baseline game logic tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "prettier": "^3.8.4",
         "typescript": "^6.0.3",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.0.15"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -864,6 +865,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -874,6 +882,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1228,6 +1254,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1429,6 +1568,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1600,6 +1749,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1950,6 +2109,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2246,6 +2412,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2261,6 +2437,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3547,6 +3733,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3721,6 +3917,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3826,6 +4036,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4327,6 +4544,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4336,6 +4560,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -4488,6 +4726,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4503,6 +4758,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4769,6 +5034,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webrtc-adapter": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
@@ -4885,6 +5240,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit --pretty false",
     "lint": "eslint . && npm run typecheck",
-    "test": "node --test",
+    "test": "vitest run",
     "verify": "npm run typecheck && npm run lint && npm test && npm run build"
   },
   "keywords": [],
@@ -27,7 +27,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "@typescript-eslint/eslint-plugin": "^8.49.1",
-    "@typescript-eslint/parser": "^8.49.1"
+    "@typescript-eslint/parser": "^8.49.1",
+    "vitest": "^4.0.15"
   },
   "dependencies": {
     "@types/react": "^19.2.17",

--- a/src/games/minesweeper/MinesweeperGame.tsx
+++ b/src/games/minesweeper/MinesweeperGame.tsx
@@ -1,17 +1,16 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import "./minesweeper.css";
-
-type Cell = {
-  mine: boolean;
-  revealed: boolean;
-  flagged: boolean;
-  adj: number; // adjacent mines
-};
-
-type Difficulty = { cols: number; rows: number; mines: number };
+import {
+  DEFAULT_DIFFICULTY,
+  type Cell,
+  computeWaveDistances,
+  createBoard,
+  hasWon,
+  placeMinesDeterministic,
+  revealFlood,
+} from "./minesweeper.logic";
 
 /** Constants */
-const DEFAULT_DIFFICULTY: Difficulty = { cols: 9, rows: 9, mines: 10 };
 const TIMER_INTERVAL_MS = 1000;
 const MAX_TIMER = 999;
 const CELL_PX = 28;
@@ -22,107 +21,6 @@ type WaveMeta = {
   waveId: number;
   dist: number;
 } | null;
-
-function inBounds(c: number, r: number, cols: number, rows: number) {
-  return c >= 0 && c < cols && r >= 0 && r < rows;
-}
-
-function neighbors(index: number, cols: number, rows: number) {
-  const r = Math.floor(index / cols);
-  const c = index % cols;
-  const result: number[] = [];
-  for (let rr = r - 1; rr <= r + 1; rr++) {
-    for (let cc = c - 1; cc <= c + 1; cc++) {
-      if (rr === r && cc === c) continue;
-      if (inBounds(cc, rr, cols, rows)) result.push(rr * cols + cc);
-    }
-  }
-  return result;
-}
-
-function createBoard(cols: number, rows: number): Cell[] {
-  return Array.from({ length: cols * rows }, () => ({
-    mine: false,
-    revealed: false,
-    flagged: false,
-    adj: 0,
-  }));
-}
-
-/**
- * Deterministic mine placement with injectable RNG.
- * Keeps "first click and neighbors are safe" guarantee.
- */
-function placeMinesDeterministic(
-  board: Cell[],
-  cols: number,
-  rows: number,
-  mines: number,
-  safeIndex: number,
-  rng: () => number
-) {
-  const forbidden = new Set([safeIndex, ...neighbors(safeIndex, cols, rows)]);
-  let placed = 0;
-  while (placed < mines) {
-    const pos = Math.floor(rng() * board.length);
-    if (forbidden.has(pos)) continue;
-    if (!board[pos].mine) {
-      board[pos].mine = true;
-      placed++;
-    }
-  }
-  // compute adj counts
-  for (let i = 0; i < board.length; i++) {
-    if (board[i].mine) continue;
-    const adj = neighbors(i, cols, rows).reduce((acc, n) => acc + (board[n].mine ? 1 : 0), 0);
-    board[i].adj = adj;
-  }
-}
-
-function revealFlood(board: Cell[], start: number, cols: number, rows: number) {
-  const stack = [start];
-  while (stack.length) {
-    const idx = stack.pop()!;
-    const cell = board[idx];
-    if (cell.revealed || cell.flagged) continue;
-    cell.revealed = true;
-    if (!cell.mine && cell.adj === 0) {
-      for (const n of neighbors(idx, cols, rows)) {
-        if (!board[n].revealed && !board[n].flagged) stack.push(n);
-      }
-    }
-  }
-}
-
-/**
- * Compute BFS distances only within the set of cells that will be revealed in this wave.
- * This mirrors legacy revealWave timing (d * 60ms), and does NOT include mines.
- */
-function computeWaveDistances(revealedNow: Set<number>, startIdx: number, cols: number, rows: number): Map<number, number> {
-  const dist = new Map<number, number>();
-  if (!revealedNow.size) return dist;
-
-  // Prefer starting wave from the clicked cell if it is part of the reveal set
-  const seed = revealedNow.has(startIdx) ? startIdx : [...revealedNow][0];
-  dist.set(seed, 0);
-
-  const q: number[] = [seed];
-  while (q.length) {
-    const u = q.shift()!;
-    const du = dist.get(u)!;
-    for (const v of neighbors(u, cols, rows)) {
-      if (!revealedNow.has(v)) continue;
-      if (dist.has(v)) continue;
-      dist.set(v, du + 1);
-      q.push(v);
-    }
-  }
-  return dist;
-}
-
-// Compute BFS distances for ripple like legacy revealWave().
-// It traverses only across cells that will be revealed in this action.
-/* duplicate removed */
 
 export default function MinesweeperGame(): React.ReactElement {
   const { cols, rows, mines } = DEFAULT_DIFFICULTY;
@@ -191,16 +89,7 @@ export default function MinesweeperGame(): React.ReactElement {
   };
 
   const checkWin = (next: Cell[]) => {
-    // win if all non-mine cells revealed
-    const total = cols * rows;
-    let revealedSafe = 0;
-    let minesCount = 0;
-    for (let i = 0; i < total; i++) {
-      const c = next[i];
-      if (c.mine) minesCount++;
-      else if (c.revealed) revealedSafe++;
-    }
-    if (minesCount === mines && revealedSafe === total - mines) {
+    if (hasWon(next, cols, rows, mines)) {
       if (timerRef.current) window.clearInterval(timerRef.current);
       setWon(true);
     }

--- a/src/games/minesweeper/minesweeper.logic.test.ts
+++ b/src/games/minesweeper/minesweeper.logic.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBoard,
+  hasWon,
+  neighbors,
+  placeMinesDeterministic,
+  revealFlood,
+} from "./minesweeper.logic";
+
+describe("minesweeper logic", () => {
+  it("keeps the first clicked cell and its neighbors safe", () => {
+    const cols = 5;
+    const rows = 5;
+    const safeIndex = 12;
+    const board = createBoard(cols, rows);
+    let value = 0.99;
+    const rng = () => {
+      value = value > 0.05 ? value - 0.07 : 0.99;
+      return value;
+    };
+
+    placeMinesDeterministic(board, cols, rows, 5, safeIndex, rng);
+
+    const forbidden = [safeIndex, ...neighbors(safeIndex, cols, rows)];
+    expect(forbidden.every((idx) => !board[idx].mine)).toBe(true);
+    expect(board.filter((cell) => cell.mine)).toHaveLength(5);
+  });
+
+  it("does not reveal flagged cells during flood reveal", () => {
+    const board = createBoard(3, 3);
+    board[1].flagged = true;
+
+    revealFlood(board, 0, 3, 3);
+
+    expect(board[0].revealed).toBe(true);
+    expect(board[1].revealed).toBe(false);
+  });
+
+  it("detects win when all non-mine cells are revealed", () => {
+    const board = createBoard(2, 2);
+    board[0].mine = true;
+    board[1].revealed = true;
+    board[2].revealed = true;
+    board[3].revealed = true;
+
+    expect(hasWon(board, 2, 2, 1)).toBe(true);
+  });
+
+  it("does not report win while at least one safe cell is hidden", () => {
+    const board = createBoard(2, 2);
+    board[0].mine = true;
+    board[1].revealed = true;
+    board[2].revealed = true;
+
+    expect(hasWon(board, 2, 2, 1)).toBe(false);
+  });
+});

--- a/src/games/minesweeper/minesweeper.logic.ts
+++ b/src/games/minesweeper/minesweeper.logic.ts
@@ -1,0 +1,123 @@
+export type Cell = {
+  mine: boolean;
+  revealed: boolean;
+  flagged: boolean;
+  adj: number;
+};
+
+export type Difficulty = { cols: number; rows: number; mines: number };
+
+export const DEFAULT_DIFFICULTY: Difficulty = { cols: 9, rows: 9, mines: 10 };
+
+export function inBounds(c: number, r: number, cols: number, rows: number): boolean {
+  return c >= 0 && c < cols && r >= 0 && r < rows;
+}
+
+export function neighbors(index: number, cols: number, rows: number): number[] {
+  const r = Math.floor(index / cols);
+  const c = index % cols;
+  const result: number[] = [];
+
+  for (let rr = r - 1; rr <= r + 1; rr++) {
+    for (let cc = c - 1; cc <= c + 1; cc++) {
+      if (rr === r && cc === c) continue;
+      if (inBounds(cc, rr, cols, rows)) result.push(rr * cols + cc);
+    }
+  }
+
+  return result;
+}
+
+export function createBoard(cols: number, rows: number): Cell[] {
+  return Array.from({ length: cols * rows }, () => ({
+    mine: false,
+    revealed: false,
+    flagged: false,
+    adj: 0,
+  }));
+}
+
+export function placeMinesDeterministic(
+  board: Cell[],
+  cols: number,
+  rows: number,
+  mines: number,
+  safeIndex: number,
+  rng: () => number
+): void {
+  const forbidden = new Set([safeIndex, ...neighbors(safeIndex, cols, rows)]);
+  let placed = 0;
+
+  while (placed < mines) {
+    const pos = Math.floor(rng() * board.length);
+    if (forbidden.has(pos)) continue;
+    if (!board[pos].mine) {
+      board[pos].mine = true;
+      placed++;
+    }
+  }
+
+  for (let i = 0; i < board.length; i++) {
+    if (board[i].mine) continue;
+    const adj = neighbors(i, cols, rows).reduce((acc, n) => acc + (board[n].mine ? 1 : 0), 0);
+    board[i].adj = adj;
+  }
+}
+
+export function revealFlood(board: Cell[], start: number, cols: number, rows: number): void {
+  const stack = [start];
+
+  while (stack.length) {
+    const idx = stack.pop()!;
+    const cell = board[idx];
+    if (cell.revealed || cell.flagged) continue;
+
+    cell.revealed = true;
+    if (!cell.mine && cell.adj === 0) {
+      for (const n of neighbors(idx, cols, rows)) {
+        if (!board[n].revealed && !board[n].flagged) stack.push(n);
+      }
+    }
+  }
+}
+
+export function computeWaveDistances(
+  revealedNow: Set<number>,
+  startIdx: number,
+  cols: number,
+  rows: number
+): Map<number, number> {
+  const dist = new Map<number, number>();
+  if (!revealedNow.size) return dist;
+
+  const seed = revealedNow.has(startIdx) ? startIdx : [...revealedNow][0];
+  dist.set(seed, 0);
+
+  const q: number[] = [seed];
+  while (q.length) {
+    const u = q.shift()!;
+    const du = dist.get(u)!;
+    for (const v of neighbors(u, cols, rows)) {
+      if (!revealedNow.has(v)) continue;
+      if (dist.has(v)) continue;
+      dist.set(v, du + 1);
+      q.push(v);
+    }
+  }
+
+  return dist;
+}
+
+export function hasWon(board: Cell[], cols: number, rows: number, mines: number): boolean {
+  const total = cols * rows;
+  let revealedSafe = 0;
+  let minesCount = 0;
+
+  for (let i = 0; i < total; i++) {
+    const c = board[i];
+    if (c.mine) minesCount++;
+    else if (c.revealed) revealedSafe++;
+  }
+
+  return minesCount === mines && revealedSafe === total - mines;
+}

--- a/src/games/snake/SnakeGame.tsx
+++ b/src/games/snake/SnakeGame.tsx
@@ -1,18 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSettings } from "@/settings/SettingsContext";
 import "./snake.css";
-
-/** Types */
-type Point = { x: number; y: number };
-type Dir = "up" | "down" | "left" | "right";
-type Vec = { x: number; y: number };
-type SnakeState = {
-  snake: Point[];
-  dir: Vec;
-  food: Point;
-  score: number;
-  alive: boolean;
-};
+import {
+  DIR_VECTORS,
+  type Dir,
+  type Point,
+  type SnakeState,
+  placeFood,
+  step,
+} from "./snake.logic";
 
 /** Constants */
 const DEFAULT_GRID_SIZE = 24;
@@ -24,12 +20,9 @@ const GRID_STROKE = "rgba(255,255,255,0.05)";
 const HEAD_COLOR = "#4caf50";
 const BODY_COLOR = "#81c784";
 const FOOD_COLOR = "#d9534f";
-const SCORE_PER_FOOD = 10;
-
 // Loop and input constants
 const TICK_BASE_MS = 1000;
 const GRID_LINE_WIDTH = 1;
-const FOOD_PLACE_ATTEMPTS = 100;
 const QUEUE_DRAIN_PER_TICK = 1 as const;
 const START_DIR: Dir = "right";
 const INITIAL_SNAKE: Point[] = [{ x: 3, y: 5 }, { x: 2, y: 5 }, { x: 1, y: 5 }];
@@ -45,58 +38,6 @@ const DIR_KEYS: Record<string, Dir | undefined> = {
   arrowright: "right",
   d: "right",
 };
-
-/** Direction vectors */
-const DIR_VECTORS: Record<Dir, Vec> = {
-  up: { x: 0, y: -1 },
-  down: { x: 0, y: 1 },
-  left: { x: -1, y: 0 },
-  right: { x: 1, y: 0 },
-};
-
-/** Pure helpers */
-function wrap(v: number, max: number): number {
-  return (v + max) % max;
-}
-
-function randInt(max: number, rng: () => number): number {
-  return Math.floor(rng() * max);
-}
-
-function placeFood(cols: number, rows: number, taken: Point[], rng: () => number): Point {
-  const takenKey = new Set(taken.map((p) => `${p.x},${p.y}`));
-  for (let attempt = 0; attempt < FOOD_PLACE_ATTEMPTS; attempt++) {
-    const p = { x: randInt(cols, rng), y: randInt(rows, rng) };
-    if (!takenKey.has(`${p.x},${p.y}`)) return p;
-  }
-  for (let y = 0; y < rows; y++) {
-    for (let x = 0; x < cols; x++) {
-      if (!takenKey.has(`${x},${y}`)) return { x, y };
-    }
-  }
-  return { x: 0, y: 0 };
-}
-
-/** Pure game step with injectable RNG */
-function step(state: SnakeState, input: Dir, cfg: { cols: number; rows: number; rng: () => number }): SnakeState {
-  if (!state.alive) return state;
-  const d = DIR_VECTORS[input];
-  const head = { x: wrap(state.snake[0].x + d.x, cfg.cols), y: wrap(state.snake[0].y + d.y, cfg.rows) };
-  const body = [head, ...state.snake];
-  const ate = head.x === state.food.x && head.y === state.food.y;
-
-  let food = state.food;
-  let score = state.score;
-  if (ate) {
-    score += SCORE_PER_FOOD;
-    food = placeFood(cfg.cols, cfg.rows, body, cfg.rng);
-  } else {
-    body.pop();
-  }
-
-  const collided = body.slice(1).some((p) => p.x === head.x && p.y === head.y);
-  return { snake: body, dir: d, food, score, alive: !collided };
-}
 
 /** Component */
 export default function SnakeGame(): React.ReactElement {

--- a/src/games/snake/snake.logic.test.ts
+++ b/src/games/snake/snake.logic.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { DIR_VECTORS, placeFood, step, type SnakeState } from "./snake.logic";
+
+describe("snake logic", () => {
+  it("moves the snake without growing when food is not eaten", () => {
+    const state: SnakeState = {
+      snake: [{ x: 3, y: 5 }, { x: 2, y: 5 }, { x: 1, y: 5 }],
+      dir: DIR_VECTORS.right,
+      food: { x: 10, y: 10 },
+      score: 0,
+      alive: true,
+    };
+
+    const next = step(state, "right", { cols: 12, rows: 12, rng: () => 0 });
+
+    expect(next.snake).toEqual([{ x: 4, y: 5 }, { x: 3, y: 5 }, { x: 2, y: 5 }]);
+    expect(next.score).toBe(0);
+    expect(next.alive).toBe(true);
+  });
+
+  it("grows and scores after eating food", () => {
+    const state: SnakeState = {
+      snake: [{ x: 3, y: 5 }, { x: 2, y: 5 }, { x: 1, y: 5 }],
+      dir: DIR_VECTORS.right,
+      food: { x: 4, y: 5 },
+      score: 0,
+      alive: true,
+    };
+
+    const next = step(state, "right", { cols: 12, rows: 12, rng: () => 0.9 });
+
+    expect(next.snake).toHaveLength(4);
+    expect(next.score).toBe(10);
+    expect(next.food).not.toEqual({ x: 4, y: 5 });
+  });
+
+  it("detects collision with its own body", () => {
+    const state: SnakeState = {
+      snake: [{ x: 2, y: 2 }, { x: 2, y: 3 }, { x: 1, y: 3 }, { x: 1, y: 2 }],
+      dir: DIR_VECTORS.down,
+      food: { x: 9, y: 9 },
+      score: 0,
+      alive: true,
+    };
+
+    const next = step(state, "down", { cols: 12, rows: 12, rng: () => 0 });
+
+    expect(next.alive).toBe(false);
+  });
+
+  it("places food on the first free cell when random attempts are blocked", () => {
+    const food = placeFood(3, 3, [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ], () => 0);
+
+    expect(food).toEqual({ x: 0, y: 1 });
+  });
+});

--- a/src/games/snake/snake.logic.ts
+++ b/src/games/snake/snake.logic.ts
@@ -1,0 +1,72 @@
+export type Point = { x: number; y: number };
+export type Dir = "up" | "down" | "left" | "right";
+export type Vec = { x: number; y: number };
+export type SnakeState = {
+  snake: Point[];
+  dir: Vec;
+  food: Point;
+  score: number;
+  alive: boolean;
+};
+
+const FOOD_PLACE_ATTEMPTS = 100;
+const SCORE_PER_FOOD = 10;
+
+export const DIR_VECTORS: Record<Dir, Vec> = {
+  up: { x: 0, y: -1 },
+  down: { x: 0, y: 1 },
+  left: { x: -1, y: 0 },
+  right: { x: 1, y: 0 },
+};
+
+export function wrap(v: number, max: number): number {
+  return (v + max) % max;
+}
+
+function randInt(max: number, rng: () => number): number {
+  return Math.floor(rng() * max);
+}
+
+export function placeFood(cols: number, rows: number, taken: Point[], rng: () => number): Point {
+  const takenKey = new Set(taken.map((p) => `${p.x},${p.y}`));
+  for (let attempt = 0; attempt < FOOD_PLACE_ATTEMPTS; attempt++) {
+    const p = { x: randInt(cols, rng), y: randInt(rows, rng) };
+    if (!takenKey.has(`${p.x},${p.y}`)) return p;
+  }
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      if (!takenKey.has(`${x},${y}`)) return { x, y };
+    }
+  }
+
+  return { x: 0, y: 0 };
+}
+
+export function step(
+  state: SnakeState,
+  input: Dir,
+  cfg: { cols: number; rows: number; rng: () => number }
+): SnakeState {
+  if (!state.alive) return state;
+
+  const d = DIR_VECTORS[input];
+  const head = {
+    x: wrap(state.snake[0].x + d.x, cfg.cols),
+    y: wrap(state.snake[0].y + d.y, cfg.rows),
+  };
+  const body = [head, ...state.snake];
+  const ate = head.x === state.food.x && head.y === state.food.y;
+
+  let food = state.food;
+  let score = state.score;
+  if (ate) {
+    score += SCORE_PER_FOOD;
+    food = placeFood(cfg.cols, cfg.rows, body, cfg.rng);
+  } else {
+    body.pop();
+  }
+
+  const collided = body.slice(1).some((p) => p.x === head.x && p.y === head.y);
+  return { snake: body, dir: d, food, score, alive: !collided };
+}


### PR DESCRIPTION
## Summary
- add Vitest as the lightweight test runner behind `npm test`
- extract pure Snake logic into `snake.logic.ts` and cover movement, scoring, food placement, and self-collision
- extract pure Minesweeper logic into `minesweeper.logic.ts` and cover safe first click mine placement, flood reveal behavior, and win detection

Closes #124

## Verification
- `npm run typecheck`
- `npm test` — 8 tests passing
- `npm run build`
- `npm run verify`