### PR TITLE
feat: restore Minesweeper difficulty selection

### DIFF
--- a/src/games/minesweeper/MinesweeperGame.tsx
+++ b/src/games/minesweeper/MinesweeperGame.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import "./minesweeper.css";
 import {
   DEFAULT_DIFFICULTY,
+  DIFFICULTIES,
   type Cell,
+  type DifficultyId,
   computeWaveDistances,
   createBoard,
   hasWon,
@@ -23,7 +25,8 @@ type WaveMeta = {
 } | null;
 
 export default function MinesweeperGame(): React.ReactElement {
-  const { cols, rows, mines } = DEFAULT_DIFFICULTY;
+  const [difficulty, setDifficulty] = useState(DEFAULT_DIFFICULTY);
+  const { cols, rows, mines } = difficulty;
 
   // Deterministic RNG lifecycle (replaces broken seed/setSeed usage)
   const seedRef = useRef<number>(Date.now() >>> 0);
@@ -71,21 +74,27 @@ export default function MinesweeperGame(): React.ReactElement {
     };
   }, [started, dead, won]);
 
-  const reset = (): void => {
+  const reset = (nextDifficulty = difficulty): void => {
     if (timerRef.current) window.clearInterval(timerRef.current);
 
     // advance seed and rebuild RNG from that seed
     seedRef.current = (seedRef.current * 1664525 + 1013904223) >>> 0;
     rebuildRng();
 
-    setBoard(createBoard(cols, rows));
+    setBoard(createBoard(nextDifficulty.cols, nextDifficulty.rows));
     setStarted(false);
     setDead(false);
     setWon(false);
     setFlags(0);
     setTime(0);
-    setWaveMeta(Array(cols * rows).fill(null));
+    setWaveMeta(Array(nextDifficulty.cols * nextDifficulty.rows).fill(null));
     waveIdRef.current = 0;
+  };
+
+  const changeDifficulty = (nextId: DifficultyId): void => {
+    const nextDifficulty = DIFFICULTIES.find((item) => item.id === nextId) ?? DEFAULT_DIFFICULTY;
+    setDifficulty(nextDifficulty);
+    reset(nextDifficulty);
   };
 
   const checkWin = (next: Cell[]) => {
@@ -222,11 +231,29 @@ export default function MinesweeperGame(): React.ReactElement {
     <div className="ms-root">
       <div className="ms-header">
         <div className="ms-counter" aria-label="Mines remaining">{String(remaining).padStart(3, "0")}</div>
-        <button className="ms-reset" onClick={reset} title="Restart">{dead ? "😵" : won ? "😎" : "🙂"}</button>
+        <button className="ms-reset" onClick={() => reset()} title="Restart">{dead ? "😵" : won ? "😎" : "🙂"}</button>
         <div className="ms-timer" aria-label="Timer">{String(time).padStart(3, "0")}</div>
       </div>
 
-      <div className="ms-grid" style={gridStyle} onContextMenu={onContext} role="grid" aria-label="Minesweeper board">
+      <div className="ms-difficulty" aria-label="Difficulty">
+        {DIFFICULTIES.map((item) => (
+          <button
+            key={item.id}
+            className="ms-difficulty-option"
+            data-active={item.id === difficulty.id ? "true" : undefined}
+            onClick={() => changeDifficulty(item.id)}
+            type="button"
+          >
+            <span>{item.label}</span>
+            <small>
+              {item.cols}×{item.rows}, {item.mines} mines
+            </small>
+          </button>
+        ))}
+      </div>
+
+      <div className="ms-grid-wrap">
+        <div className="ms-grid" style={gridStyle} onContextMenu={onContext} role="grid" aria-label="Minesweeper board">
         {board.map((cell, i) => {
           const classes = ["ms-cell"];
           if (cell.revealed) classes.push("revealed");
@@ -260,6 +287,7 @@ export default function MinesweeperGame(): React.ReactElement {
             </button>
           );
         })}
+        </div>
       </div>
 
       <div className="ms-footer">

--- a/src/games/minesweeper/minesweeper.css
+++ b/src/games/minesweeper/minesweeper.css
@@ -46,10 +46,54 @@
   transform: translateY(1px);
 }
 
+
+.ms-difficulty {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #f7f7f7;
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+}
+
+.ms-difficulty-option {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  min-width: 128px;
+  padding: 6px 10px;
+  border: 1px solid #b8b8b8;
+  border-radius: 4px;
+  background: #efefef;
+  color: #222;
+  cursor: pointer;
+  font: inherit;
+}
+
+.ms-difficulty-option:hover {
+  background: #ffffff;
+}
+
+.ms-difficulty-option[data-active="true"] {
+  background: #dceeff;
+  border-color: #6aa6d8;
+  box-shadow: inset 0 0 0 1px #6aa6d8;
+}
+
+.ms-difficulty-option small {
+  color: #555;
+  font-size: 11px;
+}
+
+.ms-grid-wrap {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 12px;
+}
+
 /* Remove gray background below the grid and mirror legacy chrome */
 .ms-grid {
-  flex: 1 1 auto;
-  padding: 12px;
   display: grid;
   gap: 1px;                /* legacy gap between tiles */
   background: transparent; /* requested: no gray panel behind board */

--- a/src/games/minesweeper/minesweeper.logic.test.ts
+++ b/src/games/minesweeper/minesweeper.logic.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  DIFFICULTIES,
   createBoard,
+  getDifficulty,
   hasWon,
   neighbors,
   placeMinesDeterministic,
@@ -53,5 +55,25 @@ describe("minesweeper logic", () => {
     board[2].revealed = true;
 
     expect(hasWon(board, 2, 2, 1)).toBe(false);
+  });
+});
+
+
+describe("minesweeper difficulty configuration", () => {
+  it("exposes classic beginner, intermediate, and expert board sizes", () => {
+    expect(DIFFICULTIES.map((difficulty) => difficulty.id)).toEqual([
+      "beginner",
+      "intermediate",
+      "expert",
+    ]);
+    expect(getDifficulty("beginner")).toMatchObject({ cols: 9, rows: 9, mines: 10 });
+    expect(getDifficulty("intermediate")).toMatchObject({ cols: 16, rows: 16, mines: 40 });
+    expect(getDifficulty("expert")).toMatchObject({ cols: 30, rows: 16, mines: 99 });
+  });
+
+  it("creates a board with the selected difficulty dimensions", () => {
+    const expert = getDifficulty("expert");
+
+    expect(createBoard(expert.cols, expert.rows)).toHaveLength(480);
   });
 });

--- a/src/games/minesweeper/minesweeper.logic.ts
+++ b/src/games/minesweeper/minesweeper.logic.ts
@@ -5,9 +5,27 @@ export type Cell = {
   adj: number;
 };
 
-export type Difficulty = { cols: number; rows: number; mines: number };
+export type DifficultyId = "beginner" | "intermediate" | "expert";
 
-export const DEFAULT_DIFFICULTY: Difficulty = { cols: 9, rows: 9, mines: 10 };
+export type Difficulty = {
+  id: DifficultyId;
+  label: string;
+  cols: number;
+  rows: number;
+  mines: number;
+};
+
+export const DIFFICULTIES: readonly Difficulty[] = [
+  { id: "beginner", label: "Beginner", cols: 9, rows: 9, mines: 10 },
+  { id: "intermediate", label: "Intermediate", cols: 16, rows: 16, mines: 40 },
+  { id: "expert", label: "Expert", cols: 30, rows: 16, mines: 99 },
+] as const;
+
+export const DEFAULT_DIFFICULTY = DIFFICULTIES[0];
+
+export function getDifficulty(id: DifficultyId): Difficulty {
+  return DIFFICULTIES.find((difficulty) => difficulty.id === id) ?? DEFAULT_DIFFICULTY;
+}
 
 export function inBounds(c: number, r: number, cols: number, rows: number): boolean {
   return c >= 0 && c < cols && r >= 0 && r < rows;


### PR DESCRIPTION
## Summary
- restore visible Minesweeper difficulty selection in the UI
- add classic Beginner, Intermediate, and Expert board configurations
- reset board, timer, flags, wave state, and mine counter when difficulty changes
- wrap the board in a scrollable container so the Expert board remains usable in smaller windows
- add tests for difficulty configuration and board sizing

Closes #125

## Verification
- `npm run typecheck`
- `npm test` — 10 tests passing
- `npm run build`
- `npm run verify`