### PR TITLE
feat: add reusable online game setup UI

### DIFF
--- a/src/games/tictactoe/TicTacToeGame.tsx
+++ b/src/games/tictactoe/TicTacToeGame.tsx
@@ -76,7 +76,7 @@ export default function TicTacToeGame(): React.ReactElement {
 
   return (
     <div className="ttt-root">
-      <MultiplayerPanel lobby={lobby} title="Kółko i Krzyżyk online" />
+      <MultiplayerPanel lobby={lobby} title="Kółko i Krzyżyk online" minPlayers={2} maxPlayers={2} />
 
       <section className="ttt-game" aria-label="Plansza Kółko i Krzyżyk">
         <div className="ttt-status">

--- a/src/multiplayer/MultiplayerPanel.tsx
+++ b/src/multiplayer/MultiplayerPanel.tsx
@@ -1,124 +1,22 @@
-import React, { useMemo, useState } from "react";
+import React from "react";
 import type { BaseMultiplayerMessage } from "./messages";
-import type { UseMultiplayerLobbyResult } from "./useMultiplayerLobby";
-import "./multiplayer-panel.css";
+import { OnlineGameSetup } from "./OnlineGameSetup";
+import type { OnlineGameSetupProps } from "./OnlineGameSetup";
 
-export type MultiplayerPanelProps<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
-  lobby: UseMultiplayerLobbyResult<TGameMessage>;
-  title?: string;
+export type MultiplayerPanelProps<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = Omit<
+  OnlineGameSetupProps<TGameMessage>,
+  "minPlayers" | "maxPlayers"
+> & {
+  minPlayers?: number;
+  maxPlayers?: number;
 };
 
-type MultiplayerPanelStatus = UseMultiplayerLobbyResult<BaseMultiplayerMessage>["status"];
-type MultiplayerPanelRole = UseMultiplayerLobbyResult<BaseMultiplayerMessage>["role"];
-
 export function MultiplayerPanel<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>({
-  lobby,
-  title = "Multiplayer",
+  minPlayers = 2,
+  maxPlayers = 2,
+  ...props
 }: MultiplayerPanelProps<TGameMessage>): React.ReactElement {
-  const [joinCode, setJoinCode] = useState("");
-  const busy = lobby.status === "hosting" || lobby.status === "joining";
-  const connected = lobby.status === "connected";
-  const canJoin = joinCode.trim().length > 0 && !busy && !connected;
-
-  const statusText = useMemo(() => getStatusText(lobby.status), [lobby.status]);
-
-  return (
-    <section className="mp-panel" aria-label={title}>
-      <header className="mp-panel-header">
-        <div>
-          <h2>{title}</h2>
-          <p>{statusText}</p>
-        </div>
-        <div className="mp-local-player" title={lobby.localPlayer.name}>
-          <span aria-hidden style={{ color: lobby.localPlayer.color }}>
-            {lobby.localPlayer.emoji}
-          </span>
-          <strong>{lobby.localPlayer.name}</strong>
-        </div>
-      </header>
-
-      <div className="mp-actions">
-        <button type="button" onClick={() => void lobby.host()} disabled={busy || connected}>
-          Utwórz grę
-        </button>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (canJoin) void lobby.join(joinCode);
-          }}
-        >
-          <label htmlFor="mp-room-code">Kod pokoju</label>
-          <input
-            id="mp-room-code"
-            type="text"
-            value={joinCode}
-            onChange={(event) => setJoinCode(event.target.value.toUpperCase())}
-            placeholder="np. ABC12"
-            disabled={busy || connected}
-            autoComplete="off"
-          />
-          <button type="submit" disabled={!canJoin}>
-            Dołącz do gry
-          </button>
-        </form>
-      </div>
-
-      {lobby.roomCode && (
-        <div className="mp-room-code" role="status">
-          Kod pokoju: <strong>{lobby.roomCode}</strong>
-        </div>
-      )}
-
-      {lobby.error && <p className="mp-error">{lobby.error.message}</p>}
-
-      <div className="mp-players">
-        <span>Ty: {roleLabel(lobby.role)}</span>
-        {lobby.remotePlayers.length > 0 ? (
-          lobby.remotePlayers.map((player) => (
-            <span key={player.id}>
-              <span aria-hidden style={{ color: player.color }}>
-                {player.emoji}
-              </span>{" "}
-              {player.name}
-            </span>
-          ))
-        ) : (
-          <span>Przeciwnik: jeszcze nie połączony</span>
-        )}
-      </div>
-
-      {connected && (
-        <button type="button" className="mp-secondary" onClick={lobby.close}>
-          Rozłącz
-        </button>
-      )}
-    </section>
-  );
-}
-
-function getStatusText(status: MultiplayerPanelStatus): string {
-  switch (status) {
-    case "idle":
-      return "Utwórz pokój albo wpisz kod od hosta.";
-    case "hosting":
-      return "Czekaj na gracza...";
-    case "joining":
-      return "Łączenie...";
-    case "connected":
-      return "Połączono. Możecie grać.";
-    case "closed":
-      return "Połączenie zostało zamknięte.";
-    case "error":
-      return "Nie udało się połączyć.";
-    default:
-      return "Status połączenia nieznany.";
-  }
-}
-
-function roleLabel(role: MultiplayerPanelRole): string {
-  if (role === "host") return "host";
-  if (role === "guest") return "gość";
-  return "brak roli";
+  return <OnlineGameSetup minPlayers={minPlayers} maxPlayers={maxPlayers} {...props} />;
 }
 
 export default MultiplayerPanel;

--- a/src/multiplayer/OnlineGameSetup.tsx
+++ b/src/multiplayer/OnlineGameSetup.tsx
@@ -1,0 +1,186 @@
+import React, { useMemo, useState } from "react";
+import type { BaseMultiplayerMessage } from "./messages";
+import type { UseMultiplayerLobbyResult } from "./useMultiplayerLobby";
+import "./online-game-setup.css";
+
+export type OnlineGameSetupProps<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage> = {
+  lobby: UseMultiplayerLobbyResult<TGameMessage>;
+  title?: string;
+  subtitle?: string;
+  minPlayers: number;
+  maxPlayers: number;
+  createLabel?: string;
+  joinLabel?: string;
+};
+
+type OnlineGameSetupStatus = UseMultiplayerLobbyResult<BaseMultiplayerMessage>["status"];
+type OnlineGameSetupRole = UseMultiplayerLobbyResult<BaseMultiplayerMessage>["role"];
+
+export function OnlineGameSetup<TGameMessage extends BaseMultiplayerMessage = BaseMultiplayerMessage>({
+  lobby,
+  title = "Gra online",
+  subtitle = "Utwórz pokój albo dołącz kodem od hosta.",
+  minPlayers,
+  maxPlayers,
+  createLabel = "Utwórz grę online",
+  joinLabel = "Dołącz",
+}: OnlineGameSetupProps<TGameMessage>): React.ReactElement {
+  const [joinCode, setJoinCode] = useState("");
+  const busy = lobby.status === "hosting" || lobby.status === "joining";
+  const connected = lobby.status === "connected";
+  const currentPlayers = 1 + lobby.remotePlayers.length;
+  const canStart = currentPlayers >= minPlayers && currentPlayers <= maxPlayers;
+  const canCreate = !busy && !connected;
+  const canJoin = joinCode.trim().length > 0 && !busy && !connected;
+  const statusText = useMemo(() => getStatusText(lobby.status, canStart), [lobby.status, canStart]);
+
+  return (
+    <section className="online-setup" aria-label={title} data-status={lobby.status}>
+      <header className="online-setup__hero">
+        <div className="online-setup__badge" aria-hidden>
+          ✨
+        </div>
+        <div className="online-setup__heading">
+          <span className="online-setup__eyebrow">Multiplayer</span>
+          <h2>{title}</h2>
+          <p>{subtitle}</p>
+        </div>
+        <div className="online-setup__player-card" title={lobby.localPlayer.name}>
+          <span className="online-setup__avatar" style={{ color: lobby.localPlayer.color }} aria-hidden>
+            {lobby.localPlayer.emoji}
+          </span>
+          <span>
+            <small>Grasz jako</small>
+            <strong>{lobby.localPlayer.name}</strong>
+          </span>
+        </div>
+      </header>
+
+      <div className="online-setup__status-row">
+        <div className="online-setup__status-pill">
+          <span className="online-setup__dot" aria-hidden />
+          {statusText}
+        </div>
+        <div className="online-setup__capacity" aria-label={`Gracze ${currentPlayers} z ${maxPlayers}`}>
+          <strong>{currentPlayers}</strong>/<span>{maxPlayers}</span> graczy
+        </div>
+      </div>
+
+      <div className="online-setup__player-meter" aria-hidden>
+        {Array.from({ length: maxPlayers }, (_, index) => (
+          <span
+            key={index}
+            data-active={index < currentPlayers ? "true" : undefined}
+            data-required={index < minPlayers ? "true" : undefined}
+          />
+        ))}
+      </div>
+
+      <div className="online-setup__actions">
+        <button type="button" className="online-setup__primary" onClick={() => void lobby.host()} disabled={!canCreate}>
+          <span aria-hidden>🚀</span>
+          {createLabel}
+        </button>
+
+        <form
+          className="online-setup__join"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (canJoin) void lobby.join(joinCode);
+          }}
+        >
+          <label htmlFor="online-room-code">Kod pokoju</label>
+          <div className="online-setup__join-row">
+            <input
+              id="online-room-code"
+              type="text"
+              value={joinCode}
+              onChange={(event) => setJoinCode(event.target.value.toUpperCase().replace(/[^A-Z0-9-]/g, ""))}
+              placeholder="ABC12"
+              disabled={busy || connected}
+              autoComplete="off"
+            />
+            <button type="submit" disabled={!canJoin}>
+              {joinLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {lobby.roomCode && (
+        <div className="online-setup__room" role="status">
+          <span>Udostępnij kod pokoju</span>
+          <strong>{lobby.roomCode}</strong>
+        </div>
+      )}
+
+      {lobby.error && <p className="online-setup__error">{lobby.error.message}</p>}
+
+      <div className="online-setup__players" aria-label="Lista graczy">
+        <PlayerChip label="Ty" emoji={lobby.localPlayer.emoji} color={lobby.localPlayer.color} role={roleLabel(lobby.role)} />
+        {lobby.remotePlayers.map((player) => (
+          <PlayerChip key={player.id} label={player.name} emoji={player.emoji} color={player.color} role="połączony" />
+        ))}
+        {Array.from({ length: Math.max(0, minPlayers - currentPlayers) }, (_, index) => (
+          <span key={`waiting-${index}`} className="online-setup__waiting-chip">
+            Czekamy na gracza
+          </span>
+        ))}
+      </div>
+
+      {connected && (
+        <button type="button" className="online-setup__disconnect" onClick={lobby.close}>
+          Rozłącz
+        </button>
+      )}
+    </section>
+  );
+}
+
+type PlayerChipProps = {
+  label: string;
+  emoji: string;
+  color: string;
+  role: string;
+};
+
+function PlayerChip({ label, emoji, color, role }: PlayerChipProps): React.ReactElement {
+  return (
+    <span className="online-setup__player-chip">
+      <span style={{ color }} aria-hidden>
+        {emoji}
+      </span>
+      <span>
+        <strong>{label}</strong>
+        <small>{role}</small>
+      </span>
+    </span>
+  );
+}
+
+function getStatusText(status: OnlineGameSetupStatus, canStart: boolean): string {
+  switch (status) {
+    case "idle":
+      return "Gotowe do utworzenia pokoju";
+    case "hosting":
+      return "Pokój utworzony, czekamy na graczy";
+    case "joining":
+      return "Łączenie z pokojem";
+    case "connected":
+      return canStart ? "Komplet, można grać" : "Połączono, czekamy na graczy";
+    case "closed":
+      return "Połączenie zamknięte";
+    case "error":
+      return "Nie udało się połączyć";
+    default:
+      return "Status połączenia nieznany";
+  }
+}
+
+function roleLabel(role: OnlineGameSetupRole): string {
+  if (role === "host") return "host";
+  if (role === "guest") return "gość";
+  return "lokalny";
+}
+
+export default OnlineGameSetup;

--- a/src/multiplayer/index.ts
+++ b/src/multiplayer/index.ts
@@ -1,6 +1,7 @@
 export { createRoomCode, isValidRoomCode, normalizeRoomCode, PeerRoomConnection } from "./peerConnection";
 export { usePeerRoom } from "./usePeerRoom";
 export { MultiplayerPanel } from "./MultiplayerPanel";
+export { OnlineGameSetup } from "./OnlineGameSetup";
 export { useMultiplayerLobby } from "./useMultiplayerLobby";
 export { usePeerHostRoom } from "./usePeerHostRoom";
 export { usePeerClientRoom } from "./usePeerClientRoom";
@@ -61,3 +62,4 @@ export type {
 } from "./hostClientRoom.types";
 export type { UsePeerHostRoomResult } from "./usePeerHostRoom";
 export type { UsePeerClientRoomResult } from "./usePeerClientRoom";
+export type { OnlineGameSetupProps } from "./OnlineGameSetup";

--- a/src/multiplayer/online-game-setup.css
+++ b/src/multiplayer/online-game-setup.css
@@ -1,0 +1,326 @@
+.online-setup {
+  position: relative;
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.28), transparent 34%),
+    radial-gradient(circle at bottom right, rgba(168, 85, 247, 0.22), transparent 32%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(30, 41, 59, 0.9));
+  color: #f8fafc;
+  box-shadow: 0 20px 48px rgba(2, 6, 23, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.online-setup::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.045) 1px, transparent 1px);
+  background-size: 26px 26px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 72%);
+}
+
+.online-setup > * {
+  position: relative;
+  z-index: 1;
+}
+
+.online-setup__hero {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.online-setup__badge {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border: 1px solid rgba(125, 211, 252, 0.45);
+  border-radius: 16px;
+  background: rgba(14, 165, 233, 0.18);
+  box-shadow: inset 0 0 18px rgba(14, 165, 233, 0.18);
+  font-size: 24px;
+}
+
+.online-setup__heading h2,
+.online-setup__heading p {
+  margin: 0;
+}
+
+.online-setup__heading h2 {
+  font-size: 20px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.online-setup__heading p {
+  margin-top: 4px;
+  color: #cbd5e1;
+  font-size: 13px;
+}
+
+.online-setup__eyebrow {
+  display: inline-block;
+  margin-bottom: 4px;
+  color: #7dd3fc;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.online-setup__player-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 148px;
+  padding: 8px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.52);
+}
+
+.online-setup__player-card small,
+.online-setup__player-chip small {
+  display: block;
+  color: #94a3b8;
+  font-size: 11px;
+}
+
+.online-setup__avatar {
+  font-size: 24px;
+  filter: drop-shadow(0 0 12px currentColor);
+}
+
+.online-setup__status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.online-setup__status-pill,
+.online-setup__capacity {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.58);
+  color: #dbeafe;
+  font-size: 13px;
+}
+
+.online-setup__capacity strong {
+  color: #bae6fd;
+}
+
+.online-setup__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #38bdf8;
+  box-shadow: 0 0 0 5px rgba(56, 189, 248, 0.14), 0 0 18px rgba(56, 189, 248, 0.8);
+}
+
+.online-setup[data-status="error"] .online-setup__dot {
+  background: #fb7185;
+  box-shadow: 0 0 0 5px rgba(251, 113, 133, 0.14), 0 0 18px rgba(251, 113, 133, 0.8);
+}
+
+.online-setup__player-meter {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(34px, 1fr));
+  gap: 6px;
+}
+
+.online-setup__player-meter span {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.26);
+}
+
+.online-setup__player-meter span[data-required="true"] {
+  background: rgba(14, 165, 233, 0.28);
+}
+
+.online-setup__player-meter span[data-active="true"] {
+  background: linear-gradient(90deg, #38bdf8, #a78bfa);
+  box-shadow: 0 0 16px rgba(56, 189, 248, 0.38);
+}
+
+.online-setup__actions {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.85fr) minmax(220px, 1.15fr);
+  gap: 12px;
+}
+
+.online-setup button,
+.online-setup input {
+  font: inherit;
+}
+
+.online-setup__primary,
+.online-setup__join button,
+.online-setup__disconnect {
+  min-height: 42px;
+  border-radius: 12px;
+  border: 1px solid rgba(125, 211, 252, 0.48);
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 0.12s ease, filter 0.12s ease, opacity 0.12s ease;
+}
+
+.online-setup__primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 16px;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #082f49;
+}
+
+.online-setup__join {
+  display: grid;
+  gap: 6px;
+}
+
+.online-setup__join label {
+  color: #cbd5e1;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.online-setup__join-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) auto;
+  gap: 8px;
+}
+
+.online-setup__join input {
+  min-height: 42px;
+  min-width: 0;
+  padding: 0 12px;
+  border: 1px solid rgba(148, 163, 184, 0.42);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.68);
+  color: #f8fafc;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  outline: none;
+}
+
+.online-setup__join input:focus {
+  border-color: #7dd3fc;
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.16);
+}
+
+.online-setup__join button {
+  padding: 0 16px;
+  background: rgba(15, 23, 42, 0.36);
+  color: #e0f2fe;
+}
+
+.online-setup__primary:not(:disabled):hover,
+.online-setup__join button:not(:disabled):hover,
+.online-setup__disconnect:not(:disabled):hover {
+  transform: translateY(-1px);
+  filter: brightness(1.08);
+}
+
+.online-setup button:disabled,
+.online-setup input:disabled {
+  cursor: not-allowed;
+  opacity: 0.54;
+}
+
+.online-setup__room {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border: 1px dashed rgba(125, 211, 252, 0.5);
+  border-radius: 14px;
+  background: rgba(14, 165, 233, 0.12);
+}
+
+.online-setup__room span {
+  color: #bae6fd;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.online-setup__room strong {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 26px;
+  letter-spacing: 0.16em;
+}
+
+.online-setup__error {
+  margin: 0;
+  color: #fecaca;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.online-setup__players {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.online-setup__player-chip,
+.online-setup__waiting-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  font-size: 13px;
+}
+
+.online-setup__waiting-chip {
+  color: #cbd5e1;
+  border-style: dashed;
+}
+
+.online-setup__disconnect {
+  justify-self: start;
+  padding: 0 14px;
+  background: rgba(15, 23, 42, 0.34);
+  color: #e2e8f0;
+}
+
+@media (max-width: 720px) {
+  .online-setup__hero,
+  .online-setup__actions {
+    grid-template-columns: 1fr;
+  }
+
+  .online-setup__player-card,
+  .online-setup__primary {
+    width: 100%;
+  }
+}
+
+@media (max-width: 460px) {
+  .online-setup {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .online-setup__join-row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `OnlineGameSetup` component for multiplayer game setup
- support `minPlayers` and `maxPlayers` props for player requirements
- redesign online setup UI with status, capacity meter, room code, player chips, and responsive layout
- keep `MultiplayerPanel` as a backward-compatible wrapper using the new component
- wire TicTacToe to pass explicit 2-player requirements

## Verification
- `npm run typecheck`
- `npm test` — 10 tests passing
- `npm run build`
- `npm run verify`

Notes: `npm run verify` still reports existing ESLint warnings in older window files, but exits with code 0.