### PR TITLE
[codex] Make component dimensions responsive

### DIFF
--- a/src/desktop/desktop.css
+++ b/src/desktop/desktop.css
@@ -11,22 +11,22 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 
 /* Desktop grid like Windows */
 .desktop-grid {
-  height: calc(100vh - 48px);
+  height: calc(100dvh - var(--taskbar-height));
   position: relative;
-  padding: var(--space-5);
+  padding: clamp(var(--space-3), 3vmin, var(--space-5));
   display: grid;
   /* Strict single column so next icon is directly under the previous one. */
-  grid-template-columns: 80px;
-  grid-auto-rows: 100px;
-  gap: var(--space-5);
+  grid-template-columns: var(--desktop-icon-column);
+  grid-auto-rows: var(--desktop-icon-row);
+  gap: clamp(var(--space-3), 3vmin, var(--space-5));
   align-content: start;
   justify-content: start;
 }
 
 /* Icons */
 .desktop-icon {
-  width: 64px;
-  height: 64px;
+  width: var(--desktop-icon-size);
+  height: var(--desktop-icon-size);
   background: rgba(255,255,255,0.1);
   border-radius: var(--radius-2);
   border: 1px solid rgba(255,255,255,0.12);
@@ -36,8 +36,8 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
   cursor: pointer;
   position: relative;
   transition: transform .15s ease, background .2s ease;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(1.25rem);
+  -webkit-backdrop-filter: blur(1.25rem);
   text-decoration: none;
   outline: none;
   color: #fff;
@@ -45,20 +45,20 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 .desktop-icon:hover { background: rgba(255,255,255,0.2); transform: scale(1.05); }
 .desktop-icon::before {
   content: attr(data-icon);
-  font-size: 32px;
+  font-size: var(--desktop-icon-font-size);
   color: #fff;
 }
 .icon-label {
   position: absolute;
-  top: 70px;
+  top: calc(var(--desktop-icon-size) + var(--space-1));
   left: 50%;
   transform: translateX(-50%);
   color: #fff;
-  font-size: 11px;
+  font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
   text-align: center;
   white-space: nowrap;
-  text-shadow: 0 1px 2px rgba(0,0,0,.5);
-  max-width: 80px;
+  text-shadow: 0 0.0625rem 0.125rem rgba(0,0,0,.5);
+  max-width: var(--desktop-icon-column);
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -67,67 +67,87 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 .taskbar {
   position: fixed;
   bottom: 0; left: 0; right: 0;
-  height: 48px;
+  height: var(--taskbar-height);
   background: rgba(0,0,0,0.8);
-  backdrop-filter: blur(40px);
-  -webkit-backdrop-filter: blur(40px);
+  backdrop-filter: blur(2.5rem);
+  -webkit-backdrop-filter: blur(2.5rem);
   display: flex; align-items: center; justify-content: center;
   border-top: 1px solid rgba(255,255,255,0.1);
   z-index: var(--z-windows);
 }
 .start-button {
-  width: 48px; height: 48px;
+  width: var(--taskbar-height);
+  height: var(--taskbar-height);
   background: transparent; border: none; cursor: pointer;
   display: flex; align-items: center; justify-content: center;
-  font-size: 20px; color: #fff;
+  font-size: clamp(1.125rem, 3vmin, 1.25rem); color: #fff;
   position: absolute; left: var(--space-2);
 }
 .start-button:hover { background: rgba(255,255,255,0.1); }
-.taskbar-apps { display: flex; align-items: center; gap: 6px; margin-left: 64px; }
+.taskbar-apps {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: calc(var(--taskbar-height) + var(--space-4));
+  max-width: min(55vw, 42rem);
+  overflow: auto hidden;
+  scrollbar-width: none;
+}
+.taskbar-apps::-webkit-scrollbar { display: none; }
 .taskbar-btn {
-  height: 32px;
+  min-height: min(2rem, calc(var(--taskbar-height) - var(--space-3)));
   padding: 0 var(--space-3);
   border-radius: var(--radius-1);
   border: 1px solid rgba(255,255,255,0.12);
   background: rgba(255,255,255,0.08);
   color: #fff;
   cursor: pointer;
+  white-space: nowrap;
 }
 .taskbar-btn:hover {
   background: rgba(255,255,255,0.18);
 }
-.system-tray { position: absolute; right: var(--space-2); display: flex; gap: var(--space-2); color: #fff; font-size: 13px; }
+.system-tray {
+  position: absolute;
+  right: var(--space-2);
+  display: flex;
+  gap: var(--space-2);
+  color: #fff;
+  font-size: clamp(0.75rem, 2vmin, 0.8125rem);
+  align-items: center;
+}
 
-.clock { min-width: 40px; text-align: right; }
+.clock { min-width: 3em; text-align: right; }
 
 /* Keyboard focus visibility for desktop icons and taskbar items */
 .desktop-icon:focus-visible,
 .taskbar-btn:focus-visible,
 .start-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
-  outline-offset: 2px;
+  outline: 0.125rem solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
+  outline-offset: 0.125rem;
   border-radius: var(--radius-1);
 }
 
 /* Trial banner: sits directly above the taskbar with consistent spacing */
 .trial-banner {
   position: fixed;
-  left: env(safe-area-inset-left, 0);
-  right: env(safe-area-inset-right, 0);
-  bottom: calc(48px + var(--space-2)); /* 48px taskbar + spacing */
+  left: max(env(safe-area-inset-left, 0px), var(--space-2));
+  right: max(env(safe-area-inset-right, 0px), var(--space-2));
+  bottom: calc(var(--taskbar-height) + var(--space-2));
   z-index: calc(var(--z-windows) + 1); /* above desktop content, below overlays */
   display: flex;
   align-items: center;
   justify-content: center;
   padding: var(--space-2) var(--space-4);
   margin: 0 auto;
-  max-width: min(960px, calc(100vw - 32px));
+  max-width: min(60rem, calc(100dvw - var(--space-4)));
   border-radius: var(--radius-2);
   border: 1px solid rgba(255,255,255,0.22);
   background: color-mix(in srgb, #0b0f19 80%, transparent);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(0.625rem);
+  -webkit-backdrop-filter: blur(0.625rem);
   color: #ffffff;
+  font-size: clamp(0.8125rem, 2vmin, 0.875rem);
   font-weight: 700; /* bold for prominence and accessibility */
   line-height: 1.2;
   text-align: center;
@@ -140,19 +160,6 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
   font-weight: 800;
 }
 
-/* Responsive typography */
-@media (min-width: 768px) {
-  .trial-banner { font-size: 14px; }
-}
-@media (max-width: 767.98px) {
-  .trial-banner {
-    font-size: 13px;
-    bottom: calc(48px + var(--space-2)); /* keep same spacing above taskbar */
-    left: var(--space-2);
-    right: var(--space-2);
-  }
-}
-
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .trial-banner {
@@ -162,12 +169,17 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 }
 
 /* Mobile tweaks */
-@media (max-width: 768px) {
+@media (max-width: 48rem) {
   .desktop-grid {
     padding: var(--space-3);
-    /* Keep single column on mobile as well */
-    grid-template-columns: 72px;
-    grid-auto-rows: 92px;
     gap: var(--space-3);
+  }
+
+  .taskbar-apps {
+    max-width: 48vw;
+  }
+
+  .system-tray span:not(.clock) {
+    display: none;
   }
 }

--- a/src/games/minesweeper/minesweeper.css
+++ b/src/games/minesweeper/minesweeper.css
@@ -1,4 +1,5 @@
 .ms-root {
+  --ms-cell-size: clamp(1.25rem, 6.5vmin, 1.75rem);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -13,45 +14,46 @@
   align-items: center;
   background: #e9ecef;
   border-bottom: 1px solid rgba(0,0,0,0.08);
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
+  gap: var(--space-2);
 }
 
 .ms-counter, .ms-timer {
   background: #000;
   color: #ff0000;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   font-family: "Courier New", monospace;
-  font-size: 16px;
+  font-size: clamp(0.875rem, 2.3vmin, 1rem);
   border: 1px inset #c0c0c0;
-  min-width: 48px;
+  min-width: 3em;
   text-align: center;
-  border-radius: 2px;
+  border-radius: 0.125rem;
 }
 
 .ms-reset {
-  width: 36px;
-  height: 36px;
+  width: clamp(2rem, 5.5vmin, 2.25rem);
+  height: clamp(2rem, 5.5vmin, 2.25rem);
   background: #c0c0c0;
-  border: 2px outset #c0c0c0;
+  border: 0.125rem outset #c0c0c0;
   cursor: pointer;
-  font-size: 16px;
+  font-size: clamp(0.875rem, 2.3vmin, 1rem);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: var(--radius-1);
   transition: transform .08s ease;
 }
 .ms-reset:active {
-  border: 2px inset #c0c0c0;
-  transform: translateY(1px);
+  border: 0.125rem inset #c0c0c0;
+  transform: translateY(0.0625rem);
 }
 
 
 .ms-difficulty {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
   background: #f7f7f7;
   border-bottom: 1px solid rgba(0,0,0,0.08);
 }
@@ -59,12 +61,12 @@
 .ms-difficulty-option {
   display: inline-flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   align-items: flex-start;
-  min-width: 128px;
-  padding: 6px 10px;
+  min-width: min(8rem, 100%);
+  padding: clamp(0.375rem, 1.5vmin, var(--space-2)) clamp(var(--space-2), 2vmin, 0.625rem);
   border: 1px solid #b8b8b8;
-  border-radius: 4px;
+  border-radius: var(--radius-1);
   background: #efefef;
   color: #222;
   cursor: pointer;
@@ -83,38 +85,38 @@
 
 .ms-difficulty-option small {
   color: #555;
-  font-size: 11px;
+  font-size: clamp(0.625rem, 1.7vmin, 0.6875rem);
 }
 
 .ms-grid-wrap {
   flex: 1 1 auto;
   overflow: auto;
-  padding: 12px;
+  padding: clamp(var(--space-2), 2vmin, var(--space-3));
 }
 
 /* Remove gray background below the grid and mirror legacy chrome */
 .ms-grid {
   display: grid;
-  gap: 1px;                /* legacy gap between tiles */
+  gap: max(1px, 0.0625rem); /* legacy gap between tiles */
   background: transparent; /* requested: no gray panel behind board */
   width: fit-content;
   margin: 0 auto;
   border: none;            /* no top/bottom inset bars */
-  perspective: 700px;      /* enable 3D feel for flip ripple */
+  perspective: 44rem;      /* enable 3D feel for flip ripple */
 }
 
 /* Tile look + subtle hover/press animation like legacy feel */
 .ms-cell {
-  width: 28px;
-  height: 28px;
+  width: var(--ms-cell-size);
+  height: var(--ms-cell-size);
   background: #c0c0c0;           /* legacy base */
-  border: 2px outset #c0c0c0;    /* bevel */
+  border: 0.125rem outset #c0c0c0;    /* bevel */
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   font-weight: 700;
-  font-size: 14px;
+  font-size: clamp(0.75rem, 2.2vmin, 0.875rem);
   user-select: none;
   color: #1b1f23;
   line-height: 1;
@@ -123,11 +125,11 @@
   transform-style: preserve-3d;
 }
 .ms-cell:hover:not(.revealed) {
-  transform: translateY(-1px);
+  transform: translateY(-0.0625rem);
 }
 .ms-cell:active:not(.revealed) {
   transform: translateY(0);         /* press back */
-  border: 2px inset #c0c0c0;        /* pressed look */
+  border: 0.125rem inset #c0c0c0;        /* pressed look */
 }
 
 /* Flip reveal animation (legacy-like) */
@@ -195,8 +197,8 @@
 .ms-cell.revealed.n8 { color: #7f7f7f; }
 
 .ms-footer {
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   background: #f7f7f7;
-  font-size: 12px;
+  font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
   color: #444;
 }

--- a/src/games/snake/snake.css
+++ b/src/games/snake/snake.css
@@ -2,24 +2,25 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 8px;
-  gap: 8px;
+  padding: clamp(var(--space-2), 2vmin, var(--space-3));
+  gap: clamp(var(--space-2), 2vmin, var(--space-3));
   box-sizing: border-box;
 }
 
 .snake-hud {
   display: flex;
   align-items: center;
-  gap: 12px;
-  font-size: 14px;
+  gap: clamp(var(--space-2), 2vmin, var(--space-3));
+  font-size: clamp(0.8125rem, 2vmin, 0.875rem);
+  flex-wrap: wrap;
 }
 
 .snake-hud button {
-  padding: 6px 10px;
+  padding: clamp(0.375rem, 1.5vmin, var(--space-2)) clamp(var(--space-2), 2vmin, 0.625rem);
   background: rgba(255,255,255,0.08);
   color: inherit;
   border: 1px solid rgba(255,255,255,0.18);
-  border-radius: 4px;
+  border-radius: var(--radius-1);
   cursor: pointer;
 }
 .snake-hud button:hover {
@@ -40,7 +41,7 @@
   place-items: center;
   background: rgba(0,0,0,0.25);
   border: 1px solid rgba(255,255,255,0.12);
-  border-radius: 6px;
+  border-radius: var(--radius-1);
   overflow: hidden; /* prevent scrollbars; canvas resizes to fit */
 }
 
@@ -50,11 +51,11 @@
   max-height: 100%;
   /* Ensure the canvas can be fully scrolled into view instead of being clipped */
   display: block;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
-  border-radius: 4px;
+  box-shadow: 0 0.5rem 1.5rem rgba(0,0,0,0.35);
+  border-radius: var(--radius-1);
 }
 
 .snake-help {
   opacity: 0.8;
-  font-size: 12px;
+  font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
 }

--- a/src/games/tictactoe/tictactoe.css
+++ b/src/games/tictactoe/tictactoe.css
@@ -1,8 +1,8 @@
 .ttt-root {
   display: grid;
-  gap: 14px;
+  gap: clamp(var(--space-2), 2vmin, var(--space-4));
   height: 100%;
-  padding: 14px;
+  padding: clamp(var(--space-2), 2vmin, var(--space-4));
   box-sizing: border-box;
   overflow: auto;
   background: #0f172a;
@@ -11,33 +11,37 @@
 
 .ttt-game {
   display: grid;
-  gap: 12px;
+  gap: clamp(var(--space-2), 1.6vmin, var(--space-3));
   justify-items: center;
+  min-height: 0;
 }
 
 .ttt-status {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: clamp(var(--space-1), 1.4vmin, var(--space-2));
   justify-content: center;
-  font-size: 14px;
+  font-size: clamp(0.8125rem, 2vmin, 0.875rem);
+  text-align: center;
 }
 
 .ttt-board {
   display: grid;
-  grid-template-columns: repeat(3, minmax(72px, 112px));
-  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(0.35rem, 1.3vmin, 0.5rem);
+  width: min(100%, 21rem, 62vmin);
 }
 
 .ttt-cell {
   aspect-ratio: 1;
   border: 1px solid rgba(125, 211, 252, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-2);
   background: rgba(15, 23, 42, 0.76);
   color: #f8fafc;
-  font-size: clamp(32px, 10vw, 56px);
+  font-size: clamp(2rem, 11vmin, 3.5rem);
   font-weight: 800;
   cursor: pointer;
+  min-width: 0;
 }
 
 .ttt-cell:disabled {
@@ -50,12 +54,12 @@
 }
 
 .ttt-reset {
-  min-height: 36px;
+  min-height: clamp(2rem, 5vmin, 2.25rem);
   border: 1px solid rgba(125, 211, 252, 0.55);
-  border-radius: 6px;
+  border-radius: var(--radius-1);
   background: #0ea5e9;
   color: #082f49;
   font-weight: 700;
   cursor: pointer;
-  padding: 0 14px;
+  padding: 0 clamp(var(--space-3), 3vmin, var(--space-4));
 }

--- a/src/multiplayer/multiplayer-panel.css
+++ b/src/multiplayer/multiplayer-panel.css
@@ -1,9 +1,9 @@
 .mp-panel {
   display: grid;
-  gap: 12px;
-  padding: 12px;
+  gap: clamp(var(--space-2), 2vmin, var(--space-3));
+  padding: clamp(var(--space-2), 2vmin, var(--space-3));
   border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 8px;
+  border-radius: var(--radius-2);
   background: rgba(15, 23, 42, 0.76);
   color: #f8fafc;
 }
@@ -12,7 +12,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: clamp(var(--space-2), 2vmin, var(--space-3));
 }
 
 .mp-panel h2,
@@ -21,58 +21,60 @@
 }
 
 .mp-panel h2 {
-  font-size: 16px;
+  font-size: clamp(0.9375rem, 2.4vmin, 1rem);
 }
 
 .mp-panel p,
 .mp-players,
 .mp-room-code {
-  font-size: 13px;
+  font-size: clamp(0.75rem, 2vmin, 0.8125rem);
 }
 
 .mp-local-player,
 .mp-players {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
 .mp-actions {
   display: grid;
-  gap: 10px;
+  gap: clamp(var(--space-2), 1.6vmin, var(--space-3));
 }
 
 .mp-actions form {
   display: grid;
-  grid-template-columns: minmax(96px, auto) minmax(120px, 1fr) auto;
+  grid-template-columns: minmax(6rem, auto) minmax(7.5rem, 1fr) auto;
   align-items: end;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .mp-actions label {
-  font-size: 12px;
+  font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
   color: #cbd5e1;
 }
 
 .mp-actions input {
-  min-height: 34px;
-  border-radius: 6px;
+  min-height: clamp(2rem, 5vmin, 2.125rem);
+  border-radius: var(--radius-1);
   border: 1px solid rgba(148, 163, 184, 0.45);
   background: rgba(15, 23, 42, 0.72);
   color: #f8fafc;
-  padding: 6px 8px;
+  padding: var(--space-1) var(--space-2);
   letter-spacing: 0.08em;
+  min-width: 0;
 }
 
 .mp-panel button {
-  min-height: 34px;
+  min-height: clamp(2rem, 5vmin, 2.125rem);
   border: 1px solid rgba(125, 211, 252, 0.55);
-  border-radius: 6px;
+  border-radius: var(--radius-1);
   background: #0ea5e9;
   color: #082f49;
   font-weight: 700;
   cursor: pointer;
+  padding: 0 var(--space-3);
 }
 
 .mp-panel button:disabled {
@@ -88,7 +90,7 @@
 
 .mp-room-code strong {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 18px;
+  font-size: clamp(1rem, 2.8vmin, 1.125rem);
   letter-spacing: 0.12em;
 }
 
@@ -96,10 +98,14 @@
   color: #fecaca;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 40rem) {
   .mp-panel-header,
   .mp-actions form {
     grid-template-columns: 1fr;
+  }
+
+  .mp-panel-header {
+    flex-direction: column;
   }
 
   .mp-actions form {

--- a/src/multiplayer/online-game-setup.css
+++ b/src/multiplayer/online-game-setup.css
@@ -1,17 +1,17 @@
 .online-setup {
   position: relative;
   display: grid;
-  gap: 14px;
-  padding: 16px;
+  gap: clamp(var(--space-2), 2vmin, var(--space-4));
+  padding: clamp(var(--space-3), 2.4vmin, var(--space-4));
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 18px;
+  border-radius: clamp(var(--radius-2), 2.5vmin, 1.125rem);
   background:
     radial-gradient(circle at top left, rgba(56, 189, 248, 0.28), transparent 34%),
     radial-gradient(circle at bottom right, rgba(168, 85, 247, 0.22), transparent 32%),
     linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(30, 41, 59, 0.9));
   color: #f8fafc;
-  box-shadow: 0 20px 48px rgba(2, 6, 23, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  box-shadow: 0 1.25rem 3rem rgba(2, 6, 23, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .online-setup::before {
@@ -21,7 +21,7 @@
   pointer-events: none;
   background-image: linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.045) 1px, transparent 1px);
-  background-size: 26px 26px;
+  background-size: clamp(1rem, 4vmin, 1.625rem) clamp(1rem, 4vmin, 1.625rem);
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 72%);
 }
 
@@ -34,19 +34,19 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
+  gap: clamp(var(--space-2), 2vmin, var(--space-3));
 }
 
 .online-setup__badge {
   display: grid;
   place-items: center;
-  width: 48px;
-  height: 48px;
+  width: clamp(2.75rem, 8vmin, 3rem);
+  height: clamp(2.75rem, 8vmin, 3rem);
   border: 1px solid rgba(125, 211, 252, 0.45);
-  border-radius: 16px;
+  border-radius: clamp(var(--radius-2), 2.5vmin, 1rem);
   background: rgba(14, 165, 233, 0.18);
-  box-shadow: inset 0 0 18px rgba(14, 165, 233, 0.18);
-  font-size: 24px;
+  box-shadow: inset 0 0 1.125rem rgba(14, 165, 233, 0.18);
+  font-size: clamp(1.25rem, 4vmin, 1.5rem);
 }
 
 .online-setup__heading h2,
@@ -55,22 +55,22 @@
 }
 
 .online-setup__heading h2 {
-  font-size: 20px;
+  font-size: clamp(1.125rem, 3vmin, 1.25rem);
   line-height: 1.15;
   letter-spacing: -0.02em;
 }
 
 .online-setup__heading p {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   color: #cbd5e1;
-  font-size: 13px;
+  font-size: clamp(0.75rem, 2vmin, 0.8125rem);
 }
 
 .online-setup__eyebrow {
   display: inline-block;
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
   color: #7dd3fc;
-  font-size: 11px;
+  font-size: clamp(0.625rem, 1.7vmin, 0.6875rem);
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -79,11 +79,11 @@
 .online-setup__player-card {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  min-width: 148px;
-  padding: 8px 10px;
+  gap: clamp(var(--space-2), 1.8vmin, 0.625rem);
+  min-width: min(9.25rem, 100%);
+  padding: var(--space-2) clamp(var(--space-2), 2vmin, 0.625rem);
   border: 1px solid rgba(148, 163, 184, 0.28);
-  border-radius: 14px;
+  border-radius: clamp(var(--radius-2), 2vmin, 0.875rem);
   background: rgba(15, 23, 42, 0.52);
 }
 
@@ -91,19 +91,19 @@
 .online-setup__player-chip small {
   display: block;
   color: #94a3b8;
-  font-size: 11px;
+  font-size: clamp(0.625rem, 1.7vmin, 0.6875rem);
 }
 
 .online-setup__avatar {
-  font-size: 24px;
-  filter: drop-shadow(0 0 12px currentColor);
+  font-size: clamp(1.25rem, 4vmin, 1.5rem);
+  filter: drop-shadow(0 0 0.75rem currentColor);
 }
 
 .online-setup__status-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: clamp(var(--space-2), 2vmin, 0.625rem);
   flex-wrap: wrap;
 }
 
@@ -111,12 +111,12 @@
 .online-setup__capacity {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
+  gap: var(--space-2);
+  padding: clamp(0.375rem, 1.5vmin, 0.4375rem) clamp(var(--space-2), 2vmin, 0.625rem);
   border-radius: 999px;
   background: rgba(15, 23, 42, 0.58);
   color: #dbeafe;
-  font-size: 13px;
+  font-size: clamp(0.75rem, 2vmin, 0.8125rem);
 }
 
 .online-setup__capacity strong {
@@ -124,26 +124,26 @@
 }
 
 .online-setup__dot {
-  width: 9px;
-  height: 9px;
+  width: clamp(0.5rem, 1.6vmin, 0.5625rem);
+  height: clamp(0.5rem, 1.6vmin, 0.5625rem);
   border-radius: 999px;
   background: #38bdf8;
-  box-shadow: 0 0 0 5px rgba(56, 189, 248, 0.14), 0 0 18px rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 0.3125rem rgba(56, 189, 248, 0.14), 0 0 1.125rem rgba(56, 189, 248, 0.8);
 }
 
 .online-setup[data-status="error"] .online-setup__dot {
   background: #fb7185;
-  box-shadow: 0 0 0 5px rgba(251, 113, 133, 0.14), 0 0 18px rgba(251, 113, 133, 0.8);
+  box-shadow: 0 0 0 0.3125rem rgba(251, 113, 133, 0.14), 0 0 1.125rem rgba(251, 113, 133, 0.8);
 }
 
 .online-setup__player-meter {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(34px, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(2rem, 1fr));
+  gap: clamp(0.25rem, 1vmin, 0.375rem);
 }
 
 .online-setup__player-meter span {
-  height: 8px;
+  height: clamp(0.375rem, 1.4vmin, 0.5rem);
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.26);
 }
@@ -154,13 +154,13 @@
 
 .online-setup__player-meter span[data-active="true"] {
   background: linear-gradient(90deg, #38bdf8, #a78bfa);
-  box-shadow: 0 0 16px rgba(56, 189, 248, 0.38);
+  box-shadow: 0 0 1rem rgba(56, 189, 248, 0.38);
 }
 
 .online-setup__actions {
   display: grid;
-  grid-template-columns: minmax(180px, 0.85fr) minmax(220px, 1.15fr);
-  gap: 12px;
+  grid-template-columns: minmax(11rem, 0.85fr) minmax(13rem, 1.15fr);
+  gap: clamp(var(--space-2), 2vmin, var(--space-3));
 }
 
 .online-setup button,
@@ -171,8 +171,8 @@
 .online-setup__primary,
 .online-setup__join button,
 .online-setup__disconnect {
-  min-height: 42px;
-  border-radius: 12px;
+  min-height: clamp(2.375rem, 6vmin, 2.625rem);
+  border-radius: clamp(var(--radius-2), 2vmin, 0.75rem);
   border: 1px solid rgba(125, 211, 252, 0.48);
   font-weight: 800;
   cursor: pointer;
@@ -183,35 +183,35 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 0 16px;
+  gap: var(--space-2);
+  padding: 0 clamp(var(--space-3), 2.5vmin, var(--space-4));
   background: linear-gradient(135deg, #38bdf8, #818cf8);
   color: #082f49;
 }
 
 .online-setup__join {
   display: grid;
-  gap: 6px;
+  gap: clamp(0.25rem, 1vmin, 0.375rem);
 }
 
 .online-setup__join label {
   color: #cbd5e1;
-  font-size: 12px;
+  font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
   font-weight: 700;
 }
 
 .online-setup__join-row {
   display: grid;
-  grid-template-columns: minmax(120px, 1fr) auto;
-  gap: 8px;
+  grid-template-columns: minmax(7.5rem, 1fr) auto;
+  gap: var(--space-2);
 }
 
 .online-setup__join input {
-  min-height: 42px;
+  min-height: clamp(2.375rem, 6vmin, 2.625rem);
   min-width: 0;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   border: 1px solid rgba(148, 163, 184, 0.42);
-  border-radius: 12px;
+  border-radius: clamp(var(--radius-2), 2vmin, 0.75rem);
   background: rgba(15, 23, 42, 0.68);
   color: #f8fafc;
   font-weight: 800;
@@ -222,11 +222,11 @@
 
 .online-setup__join input:focus {
   border-color: #7dd3fc;
-  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.16);
+  box-shadow: 0 0 0 0.1875rem rgba(125, 211, 252, 0.16);
 }
 
 .online-setup__join button {
-  padding: 0 16px;
+  padding: 0 clamp(var(--space-3), 2.5vmin, var(--space-4));
   background: rgba(15, 23, 42, 0.36);
   color: #e0f2fe;
 }
@@ -234,7 +234,7 @@
 .online-setup__primary:not(:disabled):hover,
 .online-setup__join button:not(:disabled):hover,
 .online-setup__disconnect:not(:disabled):hover {
-  transform: translateY(-1px);
+  transform: translateY(-0.0625rem);
   filter: brightness(1.08);
 }
 
@@ -246,48 +246,48 @@
 
 .online-setup__room {
   display: grid;
-  gap: 4px;
-  padding: 12px;
+  gap: var(--space-1);
+  padding: clamp(var(--space-2), 2vmin, var(--space-3));
   border: 1px dashed rgba(125, 211, 252, 0.5);
-  border-radius: 14px;
+  border-radius: clamp(var(--radius-2), 2vmin, 0.875rem);
   background: rgba(14, 165, 233, 0.12);
 }
 
 .online-setup__room span {
   color: #bae6fd;
-  font-size: 12px;
+  font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
   font-weight: 700;
 }
 
 .online-setup__room strong {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 26px;
+  font-size: clamp(1.25rem, 5vmin, 1.625rem);
   letter-spacing: 0.16em;
 }
 
 .online-setup__error {
   margin: 0;
   color: #fecaca;
-  font-size: 13px;
+  font-size: clamp(0.75rem, 2vmin, 0.8125rem);
   font-weight: 700;
 }
 
 .online-setup__players {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .online-setup__player-chip,
 .online-setup__waiting-chip {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
+  gap: var(--space-2);
+  padding: clamp(0.375rem, 1.5vmin, 0.4375rem) clamp(var(--space-2), 2vmin, 0.625rem);
   border-radius: 999px;
   background: rgba(15, 23, 42, 0.52);
   border: 1px solid rgba(148, 163, 184, 0.22);
-  font-size: 13px;
+  font-size: clamp(0.75rem, 2vmin, 0.8125rem);
 }
 
 .online-setup__waiting-chip {
@@ -297,12 +297,12 @@
 
 .online-setup__disconnect {
   justify-self: start;
-  padding: 0 14px;
+  padding: 0 clamp(var(--space-3), 2.5vmin, 0.875rem);
   background: rgba(15, 23, 42, 0.34);
   color: #e2e8f0;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 45rem) {
   .online-setup__hero,
   .online-setup__actions {
     grid-template-columns: 1fr;
@@ -314,10 +314,10 @@
   }
 }
 
-@media (max-width: 460px) {
+@media (max-width: 28.75rem) {
   .online-setup {
-    padding: 12px;
-    border-radius: 14px;
+    padding: var(--space-3);
+    border-radius: var(--radius-2);
   }
 
   .online-setup__join-row {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -15,25 +15,36 @@
   --color-accent-dark: #60a5fa;
 
   /* Spacing scale */
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 20px;
-  --space-6: 24px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
 
   /* Radius */
-  --radius-1: 6px;
-  --radius-2: 8px;
-  --radius-3: 12px;
+  --radius-1: 0.375rem;
+  --radius-2: 0.5rem;
+  --radius-3: 0.75rem;
+
+  /* Responsive shell sizing */
+  --taskbar-height: clamp(2.75rem, 7dvh, 3rem);
+  --desktop-icon-size: clamp(3rem, 8vmin, 4rem);
+  --desktop-icon-font-size: clamp(1.5rem, 4vmin, 2rem);
+  --desktop-icon-column: calc(var(--desktop-icon-size) + var(--space-4));
+  --desktop-icon-row: calc(var(--desktop-icon-size) + 2rem);
+  --window-header-height: clamp(2rem, 5dvh, 2.25rem);
+  --window-control-size: clamp(1.625rem, 4.5vmin, 1.75rem);
+  --window-viewport-gap: clamp(0.5rem, 2vmin, 1rem);
 
   /* Shadows */
-  --shadow-1: 0 2px 8px rgba(0,0,0,0.10);
-  --shadow-2: 0 12px 28px rgba(0,0,0,0.22);
-  --shadow-3: 0 14px 30px rgba(0,0,0,0.55), 0 2px 10px rgba(0,0,0,0.25);
+  --shadow-1: 0 0.125rem 0.5rem rgba(0,0,0,0.10);
+  --shadow-2: 0 0.75rem 1.75rem rgba(0,0,0,0.22);
+  --shadow-3: 0 0.875rem 1.875rem rgba(0,0,0,0.55), 0 0.125rem 0.625rem rgba(0,0,0,0.25);
 
   /* Z-index layers */
   --z-desktop: 0;
+  --z-window: 1500;
   --z-windows: 1500;
   --z-overlay: 3000;
 
@@ -66,37 +77,28 @@ body {
 /* Watermark: bottom-right, subtle, persistent, non-interactive */
 .watermark {
   position: fixed;
-  right: 10px;
-  bottom: 8px;
+  right: var(--space-3);
+  bottom: var(--space-2);
   z-index: 2147483647;
   color: #B0B0B0;
   font-family: "Segoe UI", Segoe UI, Roboto, system-ui, -apple-system, sans-serif;
+  font-size: clamp(0.75rem, 1.8vmin, 0.8125rem);
   line-height: 1.2;
   text-align: right;
   pointer-events: none; /* never intercept clicks */
   user-select: none;
   opacity: 0.9; /* semi-transparent, but readable */
   text-shadow:
-    0 1px 1px rgba(0,0,0,0.35),
-    0 0 1px rgba(0,0,0,0.25); /* soft shadow for varied backgrounds */
+    0 0.0625rem 0.0625rem rgba(0,0,0,0.35),
+    0 0 0.0625rem rgba(0,0,0,0.25); /* soft shadow for varied backgrounds */
   white-space: nowrap;
-}
-
-/* Desktop default size ~13px */
-@media (min-width: 768px) {
-  .watermark { font-size: 13px; }
-}
-
-/* Small screens: downscale slightly to avoid overlap */
-@media (max-width: 767.98px) {
-  .watermark { font-size: 12px; right: 8px; bottom: 6px; }
 }
 
 /* Focus ring for keyboard users */
 :where(button, [role="button"], a, [tabindex]) :focus-visible,
 :where(button, [role="button"], a, [tabindex]):focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
-  outline-offset: 2px;
+  outline: 0.125rem solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
+  outline-offset: 0.125rem;
   border-radius: var(--radius-1);
 }
 

--- a/src/window/WindowManager.tsx
+++ b/src/window/WindowManager.tsx
@@ -63,6 +63,35 @@ type Ctx = {
 const MIN_WIDTH_DEFAULT = 520;
 const MIN_HEIGHT_DEFAULT = 640;
 const KEY_NUDGE_STEP = 10;
+const FALLBACK_VIEWPORT_WIDTH = 960;
+const FALLBACK_VIEWPORT_HEIGHT = 720;
+const MIN_USABLE_VIEWPORT_SIZE = 280;
+
+type UsableViewportBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  margin: number;
+};
+
+type ResponsiveRectInput = {
+  width: number;
+  height: number;
+  minWidth: number;
+  minHeight: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  x: number;
+  y: number;
+};
+
+type ResponsiveRect = SavedRect & {
+  minWidth: number;
+  minHeight: number;
+  maxWidth: number;
+  maxHeight: number;
+};
 
 // Stable context for devtools; avoid redundant redefinition
 const WindowCtx = createContext<Ctx | undefined>(undefined);
@@ -76,6 +105,56 @@ export function useWindowManager(): Ctx {
   const ctx = useContext(WindowCtx);
   if (!ctx) throw new Error("useWindowManager must be used within WindowManager");
   return ctx;
+}
+
+function readCssNumber(name: string, fallback: number): number {
+  if (typeof window === "undefined") return fallback;
+
+  const raw = window.getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function getUsableViewportBounds(): UsableViewportBounds {
+  if (typeof window === "undefined") {
+    return {
+      x: 0,
+      y: 0,
+      width: FALLBACK_VIEWPORT_WIDTH,
+      height: FALLBACK_VIEWPORT_HEIGHT,
+      margin: 0,
+    };
+  }
+
+  const margin = Math.round(readCssNumber("--window-viewport-gap", 12));
+  const taskbarHeight = Math.round(readCssNumber("--taskbar-height", 48));
+
+  return {
+    x: margin,
+    y: margin,
+    width: Math.max(MIN_USABLE_VIEWPORT_SIZE, window.innerWidth - margin * 2),
+    height: Math.max(MIN_USABLE_VIEWPORT_SIZE, window.innerHeight - taskbarHeight - margin * 2),
+    margin,
+  };
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function fitWindowToViewport(input: ResponsiveRectInput): ResponsiveRect {
+  const bounds = getUsableViewportBounds();
+  const maxWidth = Math.max(1, Math.min(input.maxWidth ?? bounds.width, bounds.width));
+  const maxHeight = Math.max(1, Math.min(input.maxHeight ?? bounds.height, bounds.height));
+  const minWidth = Math.min(input.minWidth, maxWidth);
+  const minHeight = Math.min(input.minHeight, maxHeight);
+  const width = Math.round(clampNumber(input.width, minWidth, maxWidth));
+  const height = Math.round(clampNumber(input.height, minHeight, maxHeight));
+  const x = Math.round(clampNumber(input.x, bounds.x, bounds.x + bounds.width - width));
+  const y = Math.round(clampNumber(input.y, bounds.y, bounds.y + bounds.height - height));
+
+  return { x, y, width, height, minWidth, minHeight, maxWidth, maxHeight };
 }
 
 function hasPositionPatch(patch: Partial<WindowState>): boolean {
@@ -120,37 +199,40 @@ export function WindowManager({ children }: { children: React.ReactNode }): Reac
       const minWidth = spec.minWidth ?? defaults?.minWidth ?? MIN_WIDTH_DEFAULT;
       const minHeight = spec.minHeight ?? defaults?.minHeight ?? MIN_HEIGHT_DEFAULT;
 
+      const readPersistedPosition = (axis: "x" | "y"): number | undefined => {
+        if (!settings.windowDrag.persistPositions) return undefined;
+
+        try {
+          const raw = localStorage.getItem(`wm:pos:${spec.id}`);
+          if (!raw) return undefined;
+          const parsed = JSON.parse(raw);
+          return typeof parsed?.[axis] === "number" ? (parsed[axis] as number) : undefined;
+        } catch {
+          return undefined;
+        }
+      };
+
+      const x = readPersistedPosition("x") ?? spec.x ?? defaults?.x ?? 100 + Math.floor(Math.random() * 80);
+      const y = readPersistedPosition("y") ?? spec.y ?? defaults?.y ?? 60 + Math.floor(Math.random() * 60);
+      const rect = fitWindowToViewport({
+        width,
+        height,
+        minWidth,
+        minHeight,
+        maxWidth: spec.maxWidth ?? defaults?.maxWidth,
+        maxHeight: spec.maxHeight ?? defaults?.maxHeight,
+        x,
+        y,
+      });
+
       const next: WindowState = {
         id: spec.id,
         content: spec.content,
         title: spec.title ?? defaults?.title ?? spec.id,
-        x: (() => {
-          // Load persisted position if enabled
-          if (settings.windowDrag.persistPositions) {
-            try {
-              const raw = localStorage.getItem(`wm:pos:${spec.id}`);
-              if (raw) {
-                const parsed = JSON.parse(raw);
-                if (typeof parsed?.x === "number") return parsed.x as number;
-              }
-            } catch {}
-          }
-          return spec.x ?? defaults?.x ?? 100 + Math.floor(Math.random() * 80);
-        })(),
-        y: (() => {
-          if (settings.windowDrag.persistPositions) {
-            try {
-              const raw = localStorage.getItem(`wm:pos:${spec.id}`);
-              if (raw) {
-                const parsed = JSON.parse(raw);
-                if (typeof parsed?.y === "number") return parsed.y as number;
-              }
-            } catch {}
-          }
-          return spec.y ?? defaults?.y ?? 60 + Math.floor(Math.random() * 60);
-        })(),
-        width,
-        height,
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
         minWidth,
         minHeight,
         maxWidth: spec.maxWidth ?? defaults?.maxWidth ?? undefined,
@@ -180,12 +262,20 @@ export function WindowManager({ children }: { children: React.ReactNode }): Reac
         if (w.maximized) {
           const saved = w.savedRect;
           if (saved) {
+            const rect = fitWindowToViewport({
+              ...saved,
+              minWidth: w.minWidth ?? MIN_WIDTH_DEFAULT,
+              minHeight: w.minHeight ?? MIN_HEIGHT_DEFAULT,
+              maxWidth: w.maxWidth,
+              maxHeight: w.maxHeight,
+            });
+
             return {
               ...w,
-              x: saved.x,
-              y: saved.y,
-              width: saved.width,
-              height: saved.height,
+              x: rect.x,
+              y: rect.y,
+              width: rect.width,
+              height: rect.height,
               maximized: false,
               savedRect: undefined,
             };
@@ -198,13 +288,13 @@ export function WindowManager({ children }: { children: React.ReactNode }): Reac
             width: w.width,
             height: w.height,
           };
-          // Full viewport
+          const bounds = getUsableViewportBounds();
           return {
             ...w,
-            x: 0,
-            y: 0,
-            width: window.innerWidth,
-            height: window.innerHeight,
+            x: bounds.x,
+            y: bounds.y,
+            width: bounds.width,
+            height: bounds.height,
             maximized: true,
             savedRect,
           };
@@ -235,6 +325,35 @@ export function WindowManager({ children }: { children: React.ReactNode }): Reac
       prev.map((w) => (w.id === id ? { ...w, ...patch } : w))
     );
   }, [settings.windowDrag.persistPositions]);
+
+  useEffect(() => {
+    const onResize = () => {
+      setWindows((prev) =>
+        prev.map((w) => {
+          if (w.maximized) {
+            const bounds = getUsableViewportBounds();
+            return { ...w, x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height };
+          }
+
+          const rect = fitWindowToViewport({
+            x: w.x,
+            y: w.y,
+            width: w.width,
+            height: w.height,
+            minWidth: w.minWidth ?? MIN_WIDTH_DEFAULT,
+            minHeight: w.minHeight ?? MIN_HEIGHT_DEFAULT,
+            maxWidth: w.maxWidth,
+            maxHeight: w.maxHeight,
+          });
+
+          return { ...w, x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+        })
+      );
+    };
+
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   const ctx = useMemo<Ctx>(
     () => ({
@@ -281,14 +400,9 @@ export function WindowManager({ children }: { children: React.ReactNode }): Reac
               e.key === "ArrowRight" ? KEY_NUDGE_STEP : e.key === "ArrowLeft" ? -KEY_NUDGE_STEP : 0;
             const dy =
               e.key === "ArrowDown" ? KEY_NUDGE_STEP : e.key === "ArrowUp" ? -KEY_NUDGE_STEP : 0;
-            const nx = Math.max(
-              0,
-              Math.min(w.x + dx, Math.max(0, window.innerWidth - w.width)) // remove redundant nullish checks
-            );
-            const ny = Math.max(
-              0,
-              Math.min(w.y + dy, Math.max(0, window.innerHeight - w.height))
-            );
+            const bounds = getUsableViewportBounds();
+            const nx = clampNumber(w.x + dx, bounds.x, bounds.x + bounds.width - w.width);
+            const ny = clampNumber(w.y + dy, bounds.y, bounds.y + bounds.height - w.height);
             return { ...w, x: nx, y: ny };
           })
         );
@@ -334,14 +448,17 @@ function WindowFrame(props: {
 }): React.ReactElement | null {
   const { state: w } = props;
 
-  // Derive constraints
-  const minWidth = w.minWidth ?? MIN_WIDTH_DEFAULT;
-  const minHeight = w.minHeight ?? MIN_HEIGHT_DEFAULT;
+  // Derive viewport-aware constraints
+  const bounds = getUsableViewportBounds();
+  const minWidth = Math.min(w.minWidth ?? MIN_WIDTH_DEFAULT, bounds.width);
+  const minHeight = Math.min(w.minHeight ?? MIN_HEIGHT_DEFAULT, bounds.height);
+  const maxWidth = Math.min(w.maxWidth ?? bounds.width, Math.max(minWidth, bounds.x + bounds.width - w.x));
+  const maxHeight = Math.min(w.maxHeight ?? bounds.height, Math.max(minHeight, bounds.y + bounds.height - w.y));
 
   // Resize hook (kept)
   const resize = useWindowResize(
     (patch) => props.onPatch(patch),
-    { minWidth, minHeight, maxWidth: w.maxWidth, maxHeight: w.maxHeight }
+    { minWidth, minHeight, maxWidth, maxHeight }
   );
 
   useEffect(() => () => resize.onCleanup(), [resize]);

--- a/src/window/window.css
+++ b/src/window/window.css
@@ -16,28 +16,28 @@
   color: var(--window-fg, #eaeaea);
   border: 1px solid rgba(255,255,255,0.25);
   border-radius: var(--radius-2); /* softened corners with token */
-  box-shadow: var(--shadow-xl);
+  box-shadow: var(--shadow-xl, var(--shadow-3));
   overflow: hidden;
   pointer-events: auto; /* interactive */
   display: flex;
   flex-direction: column;
   /* optional subtle global glass on window body */
-  -webkit-backdrop-filter: blur(6px) saturate(120%);
-  backdrop-filter: blur(6px) saturate(120%);
-  min-width: 520px;
-  min-height: 640px;
+  -webkit-backdrop-filter: blur(0.375rem) saturate(120%);
+  backdrop-filter: blur(0.375rem) saturate(120%);
+  min-width: min(32rem, calc(100dvw - (var(--window-viewport-gap) * 2)));
+  min-height: min(40rem, calc(100dvh - (var(--window-viewport-gap) * 2)));
   /* Allow window to grow up to viewport so tall game boards are fully visible */
-  max-width: 100vw;
-  max-height: 100vh;
+  max-width: calc(100dvw - (var(--window-viewport-gap) * 2));
+  max-height: calc(100dvh - (var(--window-viewport-gap) * 2));
   z-index: var(--z-window);
   /* Enable smooth visual feedback during drag */
   will-change: left, top;
   touch-action: none; /* ensure pointer events behave consistently during drag */
 }
 
-/* Glassmorphism window titlebar — mimic legacy styles exactly */
+/* Glassmorphism window titlebar */
 .window-header {
-  height: 36px;
+  height: var(--window-header-height);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -51,11 +51,11 @@
   /* Glass look from legacy */
   background: rgba(255, 255, 255, 0.12);
   background-image: linear-gradient(135deg, rgba(255,255,255,0.25), rgba(255,255,255,0.05));
-  -webkit-backdrop-filter: blur(12px) saturate(140%);
-  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(0.75rem) saturate(140%);
+  backdrop-filter: blur(0.75rem) saturate(140%);
   border-bottom: 1px solid rgba(255,255,255,0.25);
   box-shadow:
-    0 8px 24px rgba(0, 0, 0, 0.18),
+    0 0.5rem 1.5rem rgba(0, 0, 0, 0.18),
     inset 0 1px 0 rgba(255, 255, 255, 0.25);
   color: #fff;
 }
@@ -69,11 +69,15 @@
 }
 
 .window-title {
-  font-size: 14px;
+  font-size: clamp(0.8125rem, 2vmin, 0.875rem);
   font-weight: 600;
-  letter-spacing: .2px;
-  text-shadow: 0 1px 2px rgba(0,0,0,0.35);
+  letter-spacing: .0125rem;
+  text-shadow: 0 0.0625rem 0.125rem rgba(0,0,0,0.35);
   color: #fff;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Controls to match legacy look */
@@ -83,10 +87,11 @@
   align-items: center;
   /* Keep buttons clickable but do not allow them to capture drags started on header text area */
   pointer-events: auto;
+  flex-shrink: 0;
 }
 .window-control {
-  width: 28px;
-  height: 28px;
+  width: var(--window-control-size);
+  height: var(--window-control-size);
   border: 1px solid rgba(255,255,255,0.25);
   border-radius: var(--radius-1);
   background: rgba(255,255,255,0.12);
@@ -104,7 +109,7 @@
 }
 .window-control:hover {
   background: rgba(255,255,255,0.22);
-  transform: translateY(-1px);
+  transform: translateY(-0.0625rem);
 }
 .window-control.close:hover {
   background: #e81123;
@@ -115,7 +120,7 @@
 /* Content opaque so apps do not bleed through; header remains glassy */
 .window-content {
   /* Fill remaining space below header and allow scrolling if needed */
-  height: calc(100% - 36px);
+  height: calc(100% - var(--window-header-height));
   flex: 1 1 auto;
   min-height: 0; /* prevent flex min-content from shrinking container */
   padding: 0;
@@ -127,7 +132,8 @@
 .window-resizer {
   position: absolute;
   right: 0; bottom: 0;
-  width: 16px; height: 16px;
+  width: clamp(1rem, 3vmin, 1.375rem);
+  height: clamp(1rem, 3vmin, 1.375rem);
   cursor: nwse-resize;
   background:
     linear-gradient(135deg, transparent 50%, rgba(255,255,255,0.3) 50%),
@@ -148,16 +154,16 @@
 /* Focus outlines for a11y */
 .window:focus-visible,
 .window-control:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
-  outline-offset: 2px;
+  outline: 0.125rem solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
+  outline-offset: 0.125rem;
   border-radius: var(--radius-2);
 }
 
 /* High-contrast larger hit targets when enabled via data attribute on root */
 :root[data-a11y-targets="high"] .window-resizer {
-  width: 22px;
-  height: 22px;
+  width: clamp(1.25rem, 4vmin, 1.5rem);
+  height: clamp(1.25rem, 4vmin, 1.5rem);
 }
 :root[data-a11y-targets="high"] .window-header {
-  min-height: 40px;
+  min-height: clamp(2.5rem, 6dvh, 2.75rem);
 }


### PR DESCRIPTION
## Summary

- Replaced fixed shell sizing for desktop icons, taskbar, trial banner, window chrome, and game UI with responsive CSS tokens, `clamp()`, `rem`, `vmin`, `dvh`, and `dvw`.
- Added viewport-aware window clamping when opening, maximizing, restoring, resizing the browser, and nudging windows with the keyboard.
- Updated Tic Tac Toe, multiplayer setup, Snake, and Minesweeper sizing so controls and boards scale down on smaller screens instead of forcing oversized layouts.

## Validation

- Reviewed the GitHub compare diff for the changed files.
- Could not run local `npm run verify` because the terminal environment blocks direct GitHub checkout, and materializing the full repo through Composio exceeded the connector timeout.