### PR TITLE
[codex] Fix game style shell to match Snake

### DIFF
--- a/src/games/minesweeper/minesweeper.css
+++ b/src/games/minesweeper/minesweeper.css
@@ -7,8 +7,6 @@
   padding: clamp(var(--space-2), 2vmin, var(--space-3));
   box-sizing: border-box;
   overflow: hidden;
-  background: #101418;
-  color: #f8fafc;
 }
 
 .ms-header {
@@ -87,7 +85,7 @@
 }
 
 .ms-difficulty-option small {
-  color: rgba(248,250,252,0.68);
+  opacity: 0.72;
   font-size: clamp(0.625rem, 1.7vmin, 0.6875rem);
 }
 

--- a/src/games/tictactoe/tictactoe.css
+++ b/src/games/tictactoe/tictactoe.css
@@ -6,8 +6,6 @@
   padding: clamp(var(--space-2), 2vmin, var(--space-3));
   box-sizing: border-box;
   overflow: auto;
-  background: #101418;
-  color: #f8fafc;
 }
 
 .ttt-game {
@@ -18,9 +16,6 @@
   justify-items: center;
   align-content: center;
   padding: clamp(var(--space-2), 2vmin, var(--space-3));
-  background: rgba(0,0,0,0.25);
-  border: 1px solid rgba(255,255,255,0.12);
-  border-radius: var(--radius-1);
   box-sizing: border-box;
 }
 
@@ -38,9 +33,9 @@
 .ttt-status span,
 .ttt-status strong {
   padding: var(--space-1) var(--space-2);
-  border: 1px solid rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.18);
   border-radius: var(--radius-1);
-  background: rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.08);
 }
 
 .ttt-status strong {
@@ -53,9 +48,9 @@
   gap: clamp(0.35rem, 1.3vmin, 0.5rem);
   width: min(100%, 21rem, 62vmin);
   padding: clamp(var(--space-2), 1.6vmin, var(--space-3));
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
   border-radius: var(--radius-1);
-  background: rgba(16,20,24,0.72);
+  background: rgba(0,0,0,0.25);
   box-shadow: 0 0.5rem 1.5rem rgba(0,0,0,0.35);
 }
 
@@ -64,7 +59,7 @@
   min-width: 0;
   border: 1px solid rgba(255,255,255,0.18);
   border-radius: var(--radius-1);
-  background: rgba(255,255,255,0.08);
+  background: rgba(16,20,24,0.72);
   color: #81c784;
   font-size: clamp(2rem, 11vmin, 3.5rem);
   font-weight: 800;

--- a/src/multiplayer/online-game-setup.css
+++ b/src/multiplayer/online-game-setup.css
@@ -4,10 +4,10 @@
   gap: clamp(var(--space-2), 2vmin, var(--space-3));
   padding: clamp(var(--space-2), 2vmin, var(--space-3));
   overflow: hidden;
-  border: 1px solid rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.18);
   border-radius: var(--radius-1);
-  background: rgba(0,0,0,0.25);
-  color: #f8fafc;
+  background: rgba(255,255,255,0.08);
+  color: inherit;
 }
 
 .online-setup::before {
@@ -50,7 +50,7 @@
 
 .online-setup__heading p {
   margin-top: var(--space-1);
-  color: rgba(248,250,252,0.72);
+  opacity: 0.72;
   font-size: clamp(0.75rem, 2vmin, 0.8125rem);
 }
 
@@ -70,15 +70,15 @@
   gap: clamp(var(--space-2), 1.8vmin, 0.625rem);
   min-width: min(9.25rem, 100%);
   padding: var(--space-2) clamp(var(--space-2), 2vmin, 0.625rem);
-  border: 1px solid rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.18);
   border-radius: var(--radius-1);
-  background: rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.08);
 }
 
 .online-setup__player-card small,
 .online-setup__player-chip small {
   display: block;
-  color: rgba(248,250,252,0.58);
+  opacity: 0.58;
   font-size: clamp(0.625rem, 1.7vmin, 0.6875rem);
 }
 
@@ -100,9 +100,9 @@
   align-items: center;
   gap: var(--space-2);
   padding: clamp(0.375rem, 1.5vmin, 0.4375rem) clamp(var(--space-2), 2vmin, 0.625rem);
-  border: 1px solid rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.18);
   border-radius: var(--radius-1);
-  background: rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.08);
   color: inherit;
   font-size: clamp(0.75rem, 2vmin, 0.8125rem);
 }
@@ -182,7 +182,7 @@
 }
 
 .online-setup__join label {
-  color: rgba(248,250,252,0.72);
+  opacity: 0.72;
   font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
   font-weight: 700;
 }
@@ -200,7 +200,7 @@
   border: 1px solid rgba(255,255,255,0.18);
   border-radius: var(--radius-1);
   background: rgba(0,0,0,0.25);
-  color: #f8fafc;
+  color: inherit;
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -239,7 +239,7 @@
 }
 
 .online-setup__room span {
-  color: rgba(248,250,252,0.72);
+  opacity: 0.72;
   font-size: clamp(0.6875rem, 1.8vmin, 0.75rem);
   font-weight: 700;
 }
@@ -271,13 +271,13 @@
   gap: var(--space-2);
   padding: clamp(0.375rem, 1.5vmin, 0.4375rem) clamp(var(--space-2), 2vmin, 0.625rem);
   border-radius: var(--radius-1);
-  background: rgba(255,255,255,0.06);
-  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.18);
   font-size: clamp(0.75rem, 2vmin, 0.8125rem);
 }
 
 .online-setup__waiting-chip {
-  color: rgba(248,250,252,0.72);
+  opacity: 0.72;
   border-style: dashed;
 }
 


### PR DESCRIPTION
## Summary

- Removes the forced dark background/color from TicTacToe and Minesweeper roots.
- Keeps the dark treatment on the actual play boards, matching Snake where only the board area is dark.
- Lightens the multiplayer setup panel so it no longer makes the whole TicTacToe screen feel dark.

## Validation

- Reviewed the diff against `main`; only three CSS files changed.
- No game logic or TypeScript files were modified.
- GitHub Actions CI passed for commit `0b2c21f0187703ef529374b180ce456edf7941b3`.