### PR TITLE
[codex] Fix low-height game UI scaling

### DIFF
--- a/src/desktop/desktop.css
+++ b/src/desktop/desktop.css
@@ -121,7 +121,7 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 
 /* Keyboard focus visibility for desktop icons and taskbar items */
 .desktop-icon:focus-visible,
-taskbar-btn:focus-visible,
+.taskbar-btn:focus-visible,
 .start-button:focus-visible {
   outline: 0.125rem solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
   outline-offset: 0.125rem;

--- a/src/desktop/desktop.css
+++ b/src/desktop/desktop.css
@@ -11,7 +11,7 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 
 /* Desktop grid like Windows */
 .desktop-grid {
-  height: calc(100dvh - var(--taskbar-height));
+  height: calc(100dvh - var(--taskbar-height) - var(--trial-banner-reserved-height));
   position: relative;
   padding: clamp(var(--space-3), 3vmin, var(--space-5));
   display: grid;
@@ -121,7 +121,7 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 
 /* Keyboard focus visibility for desktop icons and taskbar items */
 .desktop-icon:focus-visible,
-.taskbar-btn:focus-visible,
+taskbar-btn:focus-visible,
 .start-button:focus-visible {
   outline: 0.125rem solid color-mix(in srgb, var(--color-accent) 70%, #ffffff 30%);
   outline-offset: 0.125rem;
@@ -138,7 +138,9 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-2) var(--space-4);
+  box-sizing: border-box;
+  min-height: calc(var(--trial-banner-reserved-height) - var(--space-2));
+  padding: clamp(var(--space-1), 1.6dvh, var(--space-2)) var(--space-4);
   margin: 0 auto;
   max-width: min(60rem, calc(100dvw - var(--space-4)));
   border-radius: var(--radius-2);
@@ -147,7 +149,7 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
   backdrop-filter: blur(0.625rem);
   -webkit-backdrop-filter: blur(0.625rem);
   color: #ffffff;
-  font-size: clamp(0.8125rem, 2vmin, 0.875rem);
+  font-size: clamp(0.75rem, 1.8vmin, 0.875rem);
   font-weight: 700; /* bold for prominence and accessibility */
   line-height: 1.2;
   text-align: center;
@@ -169,6 +171,12 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
 }
 
 /* Mobile tweaks */
+@media (max-height: 42rem) {
+  .trial-banner {
+    padding-inline: var(--space-3);
+  }
+}
+
 @media (max-width: 48rem) {
   .desktop-grid {
     padding: var(--space-3);

--- a/src/games/tictactoe/tictactoe.css
+++ b/src/games/tictactoe/tictactoe.css
@@ -6,6 +6,7 @@
   padding: clamp(var(--space-2), 2vmin, var(--space-3));
   box-sizing: border-box;
   overflow: auto;
+  scrollbar-gutter: stable;
 }
 
 .ttt-game {
@@ -46,7 +47,7 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: clamp(0.35rem, 1.3vmin, 0.5rem);
-  width: min(100%, 21rem, 62vmin);
+  width: min(100%, 21rem, 62vmin, 52dvh);
   padding: clamp(var(--space-2), 1.6vmin, var(--space-3));
   border: 1px solid rgba(255,255,255,0.12);
   border-radius: var(--radius-1);
@@ -93,4 +94,42 @@
 
 .ttt-reset:hover {
   background: rgba(255,255,255,0.16);
+}
+
+@media (max-height: 44rem) {
+  .ttt-root {
+    gap: var(--space-2);
+    padding: var(--space-2);
+  }
+
+  .ttt-game {
+    gap: var(--space-2);
+    align-content: start;
+    padding: var(--space-2);
+  }
+
+  .ttt-status {
+    gap: var(--space-1);
+    font-size: 0.75rem;
+  }
+
+  .ttt-status span,
+  .ttt-status strong {
+    padding: 0.1875rem var(--space-2);
+  }
+
+  .ttt-board {
+    width: min(100%, 17rem, 58vmin, 42dvh);
+    gap: var(--space-1);
+    padding: var(--space-2);
+    box-shadow: none;
+  }
+
+  .ttt-cell {
+    font-size: clamp(1.5rem, 8vmin, 2.75rem);
+  }
+
+  .ttt-reset {
+    min-height: 1.875rem;
+  }
 }

--- a/src/multiplayer/online-game-setup.css
+++ b/src/multiplayer/online-game-setup.css
@@ -3,7 +3,8 @@
   display: grid;
   gap: clamp(var(--space-2), 2vmin, var(--space-3));
   padding: clamp(var(--space-2), 2vmin, var(--space-3));
-  overflow: hidden;
+  min-height: 0;
+  overflow: visible;
   border: 1px solid rgba(255,255,255,0.18);
   border-radius: var(--radius-1);
   background: rgba(255,255,255,0.08);
@@ -305,5 +306,109 @@
 
   .online-setup__join-row {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-height: 44rem) {
+  .online-setup {
+    gap: var(--space-2);
+    padding: var(--space-2);
+  }
+
+  .online-setup__hero {
+    gap: var(--space-2);
+  }
+
+  .online-setup__badge {
+    width: 2.125rem;
+    height: 2.125rem;
+    font-size: 1rem;
+  }
+
+  .online-setup__heading h2 {
+    font-size: 0.9375rem;
+  }
+
+  .online-setup__heading p,
+  .online-setup__eyebrow,
+  .online-setup__player-card small,
+  .online-setup__player-chip small {
+    display: none;
+  }
+
+  .online-setup__player-card {
+    min-width: auto;
+    padding: var(--space-1) var(--space-2);
+  }
+
+  .online-setup__avatar {
+    font-size: 1.125rem;
+  }
+
+  .online-setup__status-row {
+    gap: var(--space-1);
+  }
+
+  .online-setup__status-pill,
+  .online-setup__capacity,
+  .online-setup__player-chip,
+  .online-setup__waiting-chip {
+    padding: 0.25rem var(--space-2);
+    font-size: 0.75rem;
+  }
+
+  .online-setup__player-meter,
+  .online-setup__players {
+    display: none;
+  }
+
+  .online-setup__actions {
+    gap: var(--space-2);
+  }
+
+  .online-setup__primary,
+  .online-setup__join button,
+  .online-setup__join input,
+  .online-setup__disconnect {
+    min-height: 2rem;
+  }
+
+  .online-setup__primary,
+  .online-setup__join button {
+    padding-inline: var(--space-3);
+  }
+
+  .online-setup__join {
+    gap: 0.125rem;
+  }
+
+  .online-setup__join label {
+    font-size: 0.6875rem;
+  }
+
+  .online-setup__room {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-2);
+  }
+
+  .online-setup__room strong {
+    font-size: 1rem;
+  }
+}
+
+@media (max-height: 44rem) and (min-width: 34rem) {
+  .online-setup__hero {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .online-setup__actions {
+    grid-template-columns: minmax(9rem, 0.8fr) minmax(11rem, 1.2fr);
+  }
+
+  .online-setup__player-card,
+  .online-setup__primary {
+    width: auto;
   }
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -29,6 +29,7 @@
 
   /* Responsive shell sizing */
   --taskbar-height: clamp(2.75rem, 7dvh, 3rem);
+  --trial-banner-reserved-height: clamp(2.75rem, 7dvh, 3.25rem);
   --desktop-icon-size: clamp(3rem, 8vmin, 4rem);
   --desktop-icon-font-size: clamp(1.5rem, 4vmin, 2rem);
   --desktop-icon-column: calc(var(--desktop-icon-size) + var(--space-4));

--- a/src/window/window.css
+++ b/src/window/window.css
@@ -25,10 +25,10 @@
   -webkit-backdrop-filter: blur(0.375rem) saturate(120%);
   backdrop-filter: blur(0.375rem) saturate(120%);
   min-width: min(32rem, calc(100dvw - (var(--window-viewport-gap) * 2)));
-  min-height: min(40rem, calc(100dvh - (var(--window-viewport-gap) * 2)));
-  /* Allow window to grow up to viewport so tall game boards are fully visible */
+  min-height: min(20rem, calc(100dvh - var(--taskbar-height) - var(--trial-banner-reserved-height) - (var(--window-viewport-gap) * 2)));
+  /* Allow window to grow up to the safe desktop area without sliding under overlays. */
   max-width: calc(100dvw - (var(--window-viewport-gap) * 2));
-  max-height: calc(100dvh - (var(--window-viewport-gap) * 2));
+  max-height: calc(100dvh - var(--taskbar-height) - var(--trial-banner-reserved-height) - (var(--window-viewport-gap) * 2));
   z-index: var(--z-window);
   /* Enable smooth visual feedback during drag */
   will-change: left, top;


### PR DESCRIPTION
## What changed
- Reserved vertical space for the trial banner so windows and desktop content no longer sit underneath it on short screens.
- Limited window max-height to the safe desktop area above the taskbar and trial banner.
- Compact Tic Tac Toe spacing and board size on low-height viewports.
- Compact the multiplayer setup panel on low-height viewports while keeping a horizontal layout when there is enough width.

## Why
On low screens the game window could extend under the trial banner and the multiplayer panel/board had too much vertical demand, causing UI elements to visually collide instead of scaling down.

## Validation
- `git diff --check`
- `npm run verify`
  - typecheck passed
  - lint passed with existing warnings only
  - tests passed: 10/10
  - production build passed