### PR TITLE
[codex] Restrict online game controls to host

### DIFF
--- a/src/games/tictactoe/TicTacToeGame.tsx
+++ b/src/games/tictactoe/TicTacToeGame.tsx
@@ -1,13 +1,13 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { InGameMultiplayerOverlay, MultiplayerPanel, useMultiplayerLobby } from "@/multiplayer";
-import type { GameResetMessage, GameSpecificMessage } from "@/multiplayer";
+import type { GameResetMessage, GameSpecificMessage, GameStartMessage, MultiplayerRole } from "@/multiplayer";
 import "./tictactoe.css";
 
 type CellValue = "X" | "O" | null;
 type PlayerSymbol = Exclude<CellValue, null>;
 type GameMode = "menu" | "local" | "ai" | "onlineLobby" | "online";
 type TicTacToeMoveMessage = GameSpecificMessage<"tictactoe:move", { cell: number; symbol: PlayerSymbol }>;
-type TicTacToeMessage = TicTacToeMoveMessage | GameResetMessage;
+type TicTacToeMessage = TicTacToeMoveMessage | GameResetMessage | GameStartMessage;
 
 const WIN_LINES = [
   [0, 1, 2],
@@ -24,6 +24,7 @@ export default function TicTacToeGame(): React.ReactElement {
   const [mode, setMode] = useState<GameMode>("menu");
   const [board, setBoard] = useState<CellValue[]>(() => emptyBoard());
   const [turn, setTurn] = useState<PlayerSymbol>("X");
+  const lobbyRoleRef = useRef<MultiplayerRole | null>(null);
 
   const resetBoard = useCallback(() => {
     setBoard(emptyBoard());
@@ -44,8 +45,18 @@ export default function TicTacToeGame(): React.ReactElement {
 
   const handleRemoteMessage = useCallback(
     (message: TicTacToeMessage) => {
+      if (message.type === "game:start") {
+        if (lobbyRoleRef.current === "guest") {
+          resetBoard();
+          setMode("online");
+        }
+        return;
+      }
+
       if (message.type === "game:reset") {
-        resetBoard();
+        if (lobbyRoleRef.current === "guest") {
+          resetBoard();
+        }
         return;
       }
 
@@ -62,6 +73,11 @@ export default function TicTacToeGame(): React.ReactElement {
   const onlinePlayers = 1 + lobby.remotePlayers.length;
   const onlineReady = lobby.status === "connected" && onlinePlayers >= 2;
   const myOnlineSymbol: PlayerSymbol | null = lobby.role === "host" ? "X" : lobby.role === "guest" ? "O" : null;
+  const isOnlineHost = lobby.role === "host";
+
+  useEffect(() => {
+    lobbyRoleRef.current = lobby.role;
+  }, [lobby.role]);
 
   useEffect(() => {
     if (mode === "ai" && turn === "O" && !winner && !draw) {
@@ -81,6 +97,13 @@ export default function TicTacToeGame(): React.ReactElement {
     setMode(nextMode);
   };
 
+  const startOnlineGame = () => {
+    if (!onlineReady || !isOnlineHost) return;
+
+    const sent = lobby.sendMessage({ type: "game:start" });
+    if (sent) startMode("online");
+  };
+
   const backToMenu = () => {
     lobby.close();
     resetBoard();
@@ -88,10 +111,15 @@ export default function TicTacToeGame(): React.ReactElement {
   };
 
   const resetGame = () => {
-    resetBoard();
-    if (mode === "online" && lobby.status === "connected") {
-      lobby.sendMessage({ type: "game:reset" });
+    if (mode === "online") {
+      if (!isOnlineHost || lobby.status !== "connected") return;
+
+      const sent = lobby.sendMessage({ type: "game:reset" });
+      if (sent) resetBoard();
+      return;
     }
+
+    resetBoard();
   };
 
   const playCell = (cell: number) => {
@@ -146,11 +174,13 @@ export default function TicTacToeGame(): React.ReactElement {
 
         <MultiplayerPanel lobby={lobby} title="Gra online" minPlayers={2} maxPlayers={2} />
 
-        {onlineReady && (
-          <button type="button" className="ttt-start-online" onClick={() => startMode("online")}>
+        {onlineReady && isOnlineHost && (
+          <button type="button" className="ttt-start-online" onClick={startOnlineGame}>
             Rozpocznij grę
           </button>
         )}
+
+        {onlineReady && !isOnlineHost && <p className="ttt-online-note">Czekamy, aż host rozpocznie grę.</p>}
       </div>
     );
   }
@@ -190,9 +220,13 @@ export default function TicTacToeGame(): React.ReactElement {
           ))}
         </div>
 
-        <button type="button" className="ttt-reset" onClick={resetGame}>
-          Reset gry
-        </button>
+        {mode !== "online" || isOnlineHost ? (
+          <button type="button" className="ttt-reset" onClick={resetGame}>
+            Reset gry
+          </button>
+        ) : (
+          <p className="ttt-online-note">Reset gry może wykonać tylko host.</p>
+        )}
       </section>
     </div>
   );

--- a/src/games/tictactoe/tictactoe.css
+++ b/src/games/tictactoe/tictactoe.css
@@ -82,6 +82,18 @@
   margin-inline: auto;
 }
 
+.ttt-online-note {
+  width: min(100%, 34rem);
+  margin: 0 auto;
+  padding: 0.65rem 0.85rem;
+  border: 0.0625rem solid rgba(129, 199, 132, 0.28);
+  border-radius: var(--radius-1);
+  background: rgba(129, 199, 132, 0.1);
+  color: rgba(255, 255, 255, 0.88);
+  font-size: clamp(0.8rem, 2vmin, 0.95rem);
+  text-align: center;
+}
+
 .ttt-link-button {
   min-height: 2rem;
   padding-inline: 0.75rem;

--- a/src/multiplayer/index.ts
+++ b/src/multiplayer/index.ts
@@ -38,6 +38,7 @@ export type {
   GameReadyMessage,
   GameResetMessage,
   GameSpecificMessage,
+  GameStartMessage,
   MessageMetadata,
   MessageSend,
   OutgoingMultiplayerMessage,

--- a/src/multiplayer/messages.ts
+++ b/src/multiplayer/messages.ts
@@ -28,6 +28,8 @@ export type PlayerHelloMessage = BaseMultiplayerMessage<"player:hello"> & {
 
 export type GameResetMessage = BaseMultiplayerMessage<"game:reset">;
 
+export type GameStartMessage = BaseMultiplayerMessage<"game:start">;
+
 export type GameReadyMessage = BaseMultiplayerMessage<"game:ready"> & {
   ready?: boolean;
 };
@@ -37,7 +39,7 @@ export type GameErrorMessage = BaseMultiplayerMessage<"game:error"> & {
   code?: string;
 };
 
-export type CommonMultiplayerMessage = PlayerHelloMessage | GameResetMessage | GameReadyMessage | GameErrorMessage;
+export type CommonMultiplayerMessage = PlayerHelloMessage | GameResetMessage | GameStartMessage | GameReadyMessage | GameErrorMessage;
 
 export type GameSpecificMessage<TType extends string, TPayload = JsonObject> = BaseMultiplayerMessage<TType> & TPayload;
 


### PR DESCRIPTION
## Summary
- restrict online Tic-Tac-Toe start controls to the host
- add a `game:start` multiplayer message so guests enter the game only when the host starts it
- restrict online reset to the host and show guest-side helper messages

## Validation
- `npm run verify` passed in Composio remote sandbox
- Existing ESLint warnings remain in unrelated files; no errors were reported