### PR TITLE
[codex] Improve tic tac toe start screen

### DIFF
--- a/src/components/GameStartMenu.tsx
+++ b/src/components/GameStartMenu.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "./game-start-menu.css";
+
+export type GameStartMenuAction = {
+  id: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  actionLabel?: string;
+  featured?: boolean;
+  variant?: "mint" | "green" | "blue";
+  onSelect: () => void;
+};
+
+type GameStartMenuProps = {
+  title: string;
+  eyebrow?: string;
+  subtitle?: string;
+  actions: GameStartMenuAction[];
+  className?: string;
+};
+
+export function GameStartMenu({ title, eyebrow = "Gra", subtitle, actions, className }: GameStartMenuProps): React.ReactElement {
+  return (
+    <section className={["game-start-menu", className].filter(Boolean).join(" ")} aria-label={`Menu gry ${title}`}>
+      <div className="game-start-menu__hero" aria-hidden="true">
+        <div className="game-start-menu__badge">
+          <span className="game-start-menu__mark game-start-menu__mark--x">×</span>
+          <span className="game-start-menu__mark game-start-menu__mark--o">○</span>
+        </div>
+      </div>
+
+      <div className="game-start-menu__heading">
+        <span className="game-start-menu__eyebrow">{eyebrow}</span>
+        <h1>{title}</h1>
+        {subtitle && <p>{subtitle}</p>}
+      </div>
+
+      <div className="game-start-menu__actions">
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            type="button"
+            className={[
+              "game-start-card",
+              action.featured ? "game-start-card--featured" : "",
+              action.variant ? `game-start-card--${action.variant}` : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            onClick={action.onSelect}
+          >
+            <span className="game-start-card__icon" aria-hidden="true">
+              {action.icon}
+            </span>
+            <span className="game-start-card__content">
+              <strong>{action.title}</strong>
+              <span>{action.description}</span>
+            </span>
+            <span className="game-start-card__cta">{action.actionLabel ?? "Rozpocznij"}</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/game-start-menu.css
+++ b/src/components/game-start-menu.css
@@ -1,0 +1,245 @@
+.game-start-menu {
+  --game-start-surface: rgba(255, 255, 255, 0.78);
+  --game-start-border: rgba(255, 255, 255, 0.72);
+  --game-start-ink: #1f2430;
+  --game-start-muted: rgba(31, 36, 48, 0.68);
+  --game-start-accent: #2f6f68;
+  --game-start-shadow: 0 1rem 2.25rem rgba(31, 36, 48, 0.16);
+  --game-start-card-shadow: 0 0.55rem 1.1rem rgba(31, 36, 48, 0.13);
+
+  display: grid;
+  gap: clamp(0.8rem, 2.2vmin, 1.15rem);
+  width: min(100%, 45rem);
+  margin-inline: auto;
+  color: var(--game-start-ink);
+}
+
+.game-start-menu__hero {
+  display: grid;
+  place-items: center;
+}
+
+.game-start-menu__badge {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  place-items: center;
+  width: clamp(4.6rem, 17vmin, 7.3rem);
+  aspect-ratio: 1;
+  border: 0.38rem solid #285f59;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 35% 30%, rgba(183, 246, 228, 0.96), rgba(69, 155, 145, 0.82) 48%, rgba(24, 54, 67, 0.95) 100%),
+    #2f6f68;
+  box-shadow: var(--game-start-shadow), inset 0 0 0 0.28rem rgba(255, 255, 255, 0.24);
+  overflow: hidden;
+}
+
+.game-start-menu__badge::before,
+.game-start-menu__badge::after {
+  content: "";
+  position: absolute;
+  inset: 16%;
+  border: 0.18rem solid rgba(230, 255, 248, 0.72);
+  border-radius: 50%;
+}
+
+.game-start-menu__badge::after {
+  inset: 30% 10%;
+  border-left-color: transparent;
+  border-right-color: transparent;
+  transform: rotate(25deg);
+}
+
+.game-start-menu__mark {
+  position: relative;
+  z-index: 1;
+  color: rgba(241, 255, 250, 0.95);
+  font-size: clamp(2.1rem, 7.5vmin, 3.45rem);
+  font-weight: 900;
+  line-height: 1;
+  text-shadow: 0 0.2rem 0.45rem rgba(24, 54, 67, 0.38);
+}
+
+.game-start-menu__mark--o {
+  transform: translateY(-0.03em);
+}
+
+.game-start-menu__heading {
+  display: grid;
+  gap: clamp(0.25rem, 1vmin, 0.45rem);
+  text-align: center;
+}
+
+.game-start-menu__eyebrow {
+  color: var(--game-start-muted);
+  font-size: clamp(0.72rem, 1.8vmin, 0.82rem);
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.game-start-menu__heading h1 {
+  margin: 0;
+  color: var(--game-start-ink);
+  font-size: clamp(2.25rem, 8vmin, 4rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+.game-start-menu__heading p {
+  max-width: 34rem;
+  margin: 0 auto;
+  color: var(--game-start-muted);
+  font-size: clamp(0.85rem, 2vmin, 1rem);
+}
+
+.game-start-menu__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(0.7rem, 2vmin, 1rem);
+}
+
+.game-start-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-areas:
+    "icon content"
+    "cta cta";
+  gap: clamp(0.55rem, 1.6vmin, 0.8rem) clamp(0.65rem, 1.8vmin, 0.9rem);
+  align-items: start;
+  min-height: clamp(8.6rem, 25vmin, 10.2rem);
+  padding: clamp(0.85rem, 2.2vmin, 1.1rem);
+  border: 0.0625rem solid var(--game-start-border);
+  border-radius: clamp(0.75rem, 2vmin, 1rem);
+  background: linear-gradient(135deg, rgba(206, 249, 242, 0.9), rgba(145, 224, 214, 0.88));
+  box-shadow: var(--game-start-card-shadow);
+  color: var(--game-start-ink);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.14s ease, box-shadow 0.14s ease, filter 0.14s ease;
+}
+
+.game-start-card--green {
+  background: linear-gradient(135deg, rgba(222, 248, 213, 0.94), rgba(143, 216, 151, 0.9));
+}
+
+.game-start-card--blue {
+  background: linear-gradient(135deg, rgba(219, 241, 255, 0.96), rgba(138, 197, 240, 0.92));
+}
+
+.game-start-card--featured {
+  grid-column: 1 / -1;
+  grid-template-columns: auto 1fr minmax(11rem, 42%);
+  grid-template-areas: "icon content cta";
+  min-height: clamp(5.8rem, 16vmin, 7rem);
+  align-items: center;
+}
+
+.game-start-card:hover {
+  transform: translateY(-0.12rem);
+  filter: saturate(1.04);
+  box-shadow: 0 0.8rem 1.4rem rgba(31, 36, 48, 0.18);
+}
+
+.game-start-card__icon {
+  grid-area: icon;
+  display: grid;
+  place-items: center;
+  width: clamp(2.3rem, 7vmin, 3rem);
+  aspect-ratio: 1;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.34);
+  color: #1f2430;
+  font-size: clamp(1.55rem, 4.8vmin, 2.1rem);
+  line-height: 1;
+}
+
+.game-start-card__content {
+  grid-area: content;
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.game-start-card__content strong {
+  font-size: clamp(1rem, 2.7vmin, 1.3rem);
+  line-height: 1.08;
+}
+
+.game-start-card__content span {
+  color: var(--game-start-muted);
+  font-size: clamp(0.78rem, 2vmin, 0.92rem);
+  line-height: 1.25;
+}
+
+.game-start-card__cta {
+  grid-area: cta;
+  display: grid;
+  place-items: center;
+  min-height: clamp(2.05rem, 5.2vmin, 2.45rem);
+  padding-inline: 0.9rem;
+  border: 0.0625rem solid rgba(47, 111, 104, 0.22);
+  border-radius: 0.45rem;
+  background: rgba(255, 255, 255, 0.68);
+  color: #20342f;
+  font-size: clamp(0.78rem, 1.9vmin, 0.9rem);
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+@media (max-width: 38rem) {
+  .game-start-menu__actions,
+  .game-start-card,
+  .game-start-card--featured {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "icon"
+      "content"
+      "cta";
+  }
+
+  .game-start-card,
+  .game-start-card--featured {
+    min-height: 0;
+  }
+
+  .game-start-card__icon {
+    width: clamp(2.15rem, 10vmin, 2.7rem);
+  }
+}
+
+@media (max-height: 42rem) {
+  .game-start-menu {
+    gap: 0.55rem;
+  }
+
+  .game-start-menu__badge {
+    width: clamp(3.6rem, 13vmin, 5rem);
+    border-width: 0.25rem;
+  }
+
+  .game-start-menu__heading h1 {
+    font-size: clamp(1.7rem, 7vmin, 2.7rem);
+  }
+
+  .game-start-menu__actions {
+    gap: 0.55rem;
+  }
+
+  .game-start-card {
+    min-height: 0;
+    padding: 0.65rem;
+  }
+
+  .game-start-card--featured {
+    min-height: 0;
+  }
+
+  .game-start-card__content span {
+    font-size: 0.76rem;
+  }
+}

--- a/src/components/game-start-menu.css
+++ b/src/components/game-start-menu.css
@@ -1,9 +1,7 @@
 .game-start-menu {
-  --game-start-surface: rgba(255, 255, 255, 0.78);
   --game-start-border: rgba(255, 255, 255, 0.72);
   --game-start-ink: #1f2430;
   --game-start-muted: rgba(31, 36, 48, 0.68);
-  --game-start-accent: #2f6f68;
   --game-start-shadow: 0 1rem 2.25rem rgba(31, 36, 48, 0.16);
   --game-start-card-shadow: 0 0.55rem 1.1rem rgba(31, 36, 48, 0.13);
 

--- a/src/games/tictactoe/TicTacToeGame.tsx
+++ b/src/games/tictactoe/TicTacToeGame.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { GameStartMenu, type GameStartMenuAction } from "@/components/GameStartMenu";
 import { InGameMultiplayerOverlay, MultiplayerPanel, useMultiplayerLobby } from "@/multiplayer";
 import type { GameResetMessage, GameSpecificMessage, GameStartMessage, MultiplayerRole } from "@/multiplayer";
 import "./tictactoe.css";
@@ -141,24 +142,43 @@ export default function TicTacToeGame(): React.ReactElement {
     }
   };
 
+  const menuActions: GameStartMenuAction[] = [
+    {
+      id: "local",
+      title: "Gra lokalna",
+      description: "Zagraj ze znajomym na tym samym ekranie.",
+      icon: "♟",
+      variant: "mint",
+      onSelect: () => startMode("local"),
+    },
+    {
+      id: "ai",
+      title: "Gra z komputerem",
+      description: "Zmierz się z komputerem w szybkiej partii.",
+      icon: "▣",
+      variant: "green",
+      onSelect: () => startMode("ai"),
+    },
+    {
+      id: "online",
+      title: "Gra online",
+      description: "Rywalizuj z graczem z innego ekranu.",
+      icon: "◎",
+      actionLabel: "Dołącz do gry",
+      featured: true,
+      variant: "blue",
+      onSelect: () => startMode("onlineLobby"),
+    },
+  ];
+
   if (mode === "menu") {
     return (
       <div className="ttt-root ttt-root--menu">
-        <section className="ttt-menu" aria-label="Menu gry Kółko i Krzyżyk">
-          <span className="ttt-menu__eyebrow">Gra</span>
-          <h1>Kółko i Krzyżyk</h1>
-          <div className="ttt-menu__actions">
-            <button type="button" onClick={() => startMode("local")}>
-              Gra lokalna
-            </button>
-            <button type="button" onClick={() => startMode("ai")}>
-              Gra z komputerem
-            </button>
-            <button type="button" onClick={() => startMode("onlineLobby")}>
-              Gra online
-            </button>
-          </div>
-        </section>
+        <GameStartMenu
+          title="Kółko i Krzyżyk"
+          subtitle="Wybierz tryb i rozpocznij krótką partię w klasycznym stylu."
+          actions={menuActions}
+        />
       </div>
     );
   }

--- a/src/games/tictactoe/tictactoe.css
+++ b/src/games/tictactoe/tictactoe.css
@@ -13,39 +13,12 @@
 .ttt-root--menu {
   align-items: center;
   justify-content: center;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(211, 241, 224, 0.75), transparent 34%),
+    radial-gradient(circle at 88% 18%, rgba(198, 236, 207, 0.7), transparent 32%),
+    linear-gradient(180deg, rgba(244, 247, 248, 0.96), rgba(225, 231, 236, 0.96));
 }
 
-.ttt-menu {
-  display: grid;
-  gap: clamp(0.9rem, 2.6vmin, 1.25rem);
-  width: min(100%, 28rem);
-  padding: clamp(1rem, 4vmin, 1.6rem);
-  border: 0.0625rem solid rgba(255, 255, 255, 0.18);
-  border-radius: var(--radius-1);
-  background: rgba(255, 255, 255, 0.08);
-  text-align: center;
-}
-
-.ttt-menu h1 {
-  margin: 0;
-  font-size: clamp(1.8rem, 8vmin, 3rem);
-  line-height: 1;
-}
-
-.ttt-menu__eyebrow {
-  color: #81c784;
-  font-size: clamp(0.72rem, 2vmin, 0.8rem);
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.ttt-menu__actions {
-  display: grid;
-  gap: 0.65rem;
-}
-
-.ttt-menu__actions button,
 .ttt-start-online,
 .ttt-link-button,
 .ttt-reset {
@@ -59,7 +32,6 @@
   cursor: pointer;
 }
 
-.ttt-menu__actions button:hover,
 .ttt-start-online:hover,
 .ttt-link-button:hover,
 .ttt-reset:hover {
@@ -180,7 +152,6 @@
     padding: 0.65rem;
   }
 
-  .ttt-menu,
   .ttt-game {
     padding: 0.75rem;
   }
@@ -194,15 +165,6 @@
   .ttt-root {
     gap: 0.5rem;
     padding: 0.6rem;
-  }
-
-  .ttt-menu {
-    gap: 0.55rem;
-    padding: 0.75rem;
-  }
-
-  .ttt-menu h1 {
-    font-size: clamp(1.4rem, 7vmin, 2.2rem);
   }
 
   .ttt-game {
@@ -232,7 +194,6 @@
     font-size: clamp(1.5rem, 8vmin, 2.75rem);
   }
 
-  .ttt-menu__actions button,
   .ttt-start-online,
   .ttt-link-button,
   .ttt-reset {


### PR DESCRIPTION
## Co zmieniono

- Dodano reużywalny komponent `GameStartMenu` do ekranów startowych gier.
- Przebudowano ekran startowy gry „Kółko i Krzyżyk” na układ z kartami trybów gry.
- Wydzielono wspólne style menu startowego do `src/components/game-start-menu.css`.
- Usunięto stare, lokalne style menu z `tictactoe.css` i dodano jasne tło dla ekranu startowego.

## Walidacja

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm run lint` ✅, istniejące ostrzeżenia bez błędów
- `npm test` ✅