### PR TITLE
[codex] Add winning line to tic tac toe

### DIFF
--- a/src/games/tictactoe/TicTacToeGame.tsx
+++ b/src/games/tictactoe/TicTacToeGame.tsx
@@ -9,6 +9,8 @@ type PlayerSymbol = Exclude<CellValue, null>;
 type GameMode = "menu" | "local" | "ai" | "onlineLobby" | "online";
 type TicTacToeMoveMessage = GameSpecificMessage<"tictactoe:move", { cell: number; symbol: PlayerSymbol }>;
 type TicTacToeMessage = TicTacToeMoveMessage | GameResetMessage | GameStartMessage;
+type WinningLine = (typeof WIN_LINES)[number];
+type WinResult = { symbol: PlayerSymbol; line: WinningLine };
 
 const WIN_LINES = [
   [0, 1, 2],
@@ -69,7 +71,9 @@ export default function TicTacToeGame(): React.ReactElement {
   );
 
   const lobby = useMultiplayerLobby<TicTacToeMessage>({ onGameMessage: handleRemoteMessage });
-  const winner = useMemo(() => getWinner(board), [board]);
+  const winResult = useMemo(() => getWinResult(board), [board]);
+  const winner = winResult?.symbol ?? null;
+  const winningLineClass = winResult ? getWinningLineClass(winResult.line) : null;
   const draw = !winner && board.every(Boolean);
   const onlinePlayers = 1 + lobby.remotePlayers.length;
   const onlineReady = lobby.status === "connected" && onlinePlayers >= 2;
@@ -225,7 +229,11 @@ export default function TicTacToeGame(): React.ReactElement {
           {draw && <strong>Remis</strong>}
         </div>
 
-        <div className="ttt-board" role="grid" aria-label="Plansza 3 na 3">
+        <div
+          className={["ttt-board", winningLineClass ? "ttt-board--won" : "", winningLineClass].filter(Boolean).join(" ")}
+          role="grid"
+          aria-label="Plansza 3 na 3"
+        >
           {board.map((value, index) => (
             <button
               key={index}
@@ -238,6 +246,7 @@ export default function TicTacToeGame(): React.ReactElement {
               {value}
             </button>
           ))}
+          {winningLineClass && <span className="ttt-winning-line" aria-hidden="true" />}
         </div>
 
         {mode !== "online" || isOnlineHost ? (
@@ -256,14 +265,28 @@ function emptyBoard(): CellValue[] {
   return Array<CellValue>(9).fill(null);
 }
 
-function getWinner(board: CellValue[]): PlayerSymbol | null {
-  for (const [a, b, c] of WIN_LINES) {
+function getWinResult(board: CellValue[]): WinResult | null {
+  for (const line of WIN_LINES) {
+    const [a, b, c] = line;
     if (board[a] && board[a] === board[b] && board[a] === board[c]) {
-      return board[a];
+      return { symbol: board[a], line };
     }
   }
 
   return null;
+}
+
+function getWinningLineClass(line: WinningLine): string {
+  const key = line.join("-");
+
+  if (key === "0-1-2") return "ttt-board--win-row-0";
+  if (key === "3-4-5") return "ttt-board--win-row-1";
+  if (key === "6-7-8") return "ttt-board--win-row-2";
+  if (key === "0-3-6") return "ttt-board--win-col-0";
+  if (key === "1-4-7") return "ttt-board--win-col-1";
+  if (key === "2-5-8") return "ttt-board--win-col-2";
+  if (key === "0-4-8") return "ttt-board--win-diagonal-down";
+  return "ttt-board--win-diagonal-up";
 }
 
 function canPlayInMode(

--- a/src/games/tictactoe/tictactoe.css
+++ b/src/games/tictactoe/tictactoe.css
@@ -192,6 +192,7 @@
 }
 
 .ttt-board {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: clamp(0.4rem, 1.4vmin, 0.6rem);
@@ -204,6 +205,8 @@
 }
 
 .ttt-cell {
+  position: relative;
+  z-index: 1;
   aspect-ratio: 1;
   min-width: 0;
   border: 0.0625rem solid rgba(47, 111, 104, 0.2);
@@ -228,6 +231,73 @@
   border-color: rgba(47, 111, 104, 0.36);
   box-shadow: 0 0.55rem 0.95rem rgba(31, 36, 48, 0.12);
   transform: translateY(-0.08rem);
+}
+
+.ttt-winning-line {
+  position: absolute;
+  z-index: 2;
+  display: block;
+  height: clamp(0.35rem, 1.4vmin, 0.55rem);
+  border-radius: 999rem;
+  background: linear-gradient(90deg, #25544f, #2f6f68 48%, #173f3b);
+  box-shadow: 0 0.2rem 0.65rem rgba(23, 63, 59, 0.28);
+  pointer-events: none;
+  transform: translateY(-50%);
+  transform-origin: center;
+}
+
+.ttt-board--win-row-0 .ttt-winning-line,
+.ttt-board--win-row-1 .ttt-winning-line,
+.ttt-board--win-row-2 .ttt-winning-line {
+  left: 9%;
+  width: 82%;
+}
+
+.ttt-board--win-row-0 .ttt-winning-line {
+  top: 16.666%;
+}
+
+.ttt-board--win-row-1 .ttt-winning-line {
+  top: 50%;
+}
+
+.ttt-board--win-row-2 .ttt-winning-line {
+  top: 83.333%;
+}
+
+.ttt-board--win-col-0 .ttt-winning-line,
+.ttt-board--win-col-1 .ttt-winning-line,
+.ttt-board--win-col-2 .ttt-winning-line {
+  top: 50%;
+  width: 82%;
+  transform: translateY(-50%) rotate(90deg);
+}
+
+.ttt-board--win-col-0 .ttt-winning-line {
+  left: -24.333%;
+}
+
+.ttt-board--win-col-1 .ttt-winning-line {
+  left: 9%;
+}
+
+.ttt-board--win-col-2 .ttt-winning-line {
+  left: 42.333%;
+}
+
+.ttt-board--win-diagonal-down .ttt-winning-line,
+.ttt-board--win-diagonal-up .ttt-winning-line {
+  left: -8%;
+  top: 50%;
+  width: 116%;
+}
+
+.ttt-board--win-diagonal-down .ttt-winning-line {
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.ttt-board--win-diagonal-up .ttt-winning-line {
+  transform: translateY(-50%) rotate(-45deg);
 }
 
 .ttt-reset {


### PR DESCRIPTION
## Co zmieniono

- Dodano wykrywanie konkretnej zwycięskiej linii w TicTacToe.
- Po wygranej plansza renderuje kreskę przez trzy zwycięskie symbole.
- Obsłużono wszystkie warianty: 3 rzędy, 3 kolumny i 2 przekątne.
- Zmiana jest wizualna, bez zmiany zasad gry ani komunikacji multiplayer.

## Walidacja

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm run lint` ✅, istniejące ostrzeżenia bez błędów
- `npm test` ✅