### PR TITLE
[codex] Update README and package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run the current lint baseline:
 npm run lint
 ```
 
-`lint` runs ESLint for JavaScript/config files and TypeScript checking for TS/TSX sources. A fuller type-aware ESLint setup can be added separately when the ESLint TypeScript parser is introduced.
+`lint` runs ESLint for JavaScript, TypeScript, TSX and config files. The ESLint setup uses the TypeScript parser for TS/TSX sources and also runs `npm run typecheck`, so linting catches both style/rule issues and TypeScript compilation problems.
 
 Run automated tests:
 
@@ -58,13 +58,15 @@ Run automated tests:
 npm test
 ```
 
-The project currently uses Node's built-in test runner. With no test files present, this command exits successfully and reports zero tests instead of failing as a placeholder.
+The project uses Vitest (`vitest run`) for automated tests. Current coverage includes game logic tests for Snake and Minesweeper, and new reusable game logic should be covered with matching `*.test.ts` files.
 
 Run all merge checks:
 
 ```sh
 npm run verify
 ```
+
+`verify` runs TypeScript checks, linting, Vitest tests and a production build. This is the same command used by CI before merging.
 
 ## Pull request checks
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "description": "",
   "type": "module",
-  "private": "true",
+  "private": true,
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Summary

- update README verification docs to match the current Vitest and ESLint setup
- remove the outdated note about Node's built-in test runner and missing tests
- change `private` in `package.json` from string to boolean

## Validation

- Compared branch against `main` and confirmed the PR only changes `README.md` and `package.json`
- Checked that `package.json` remains valid JSON
- Could not run `npm run verify` locally because direct terminal access to GitHub checkout is blocked in this environment

Closes #166