### PR TITLE
[codex] Extract Tic Tac Toe logic

### DIFF
--- a/src/games/tictactoe/TicTacToeGame.tsx
+++ b/src/games/tictactoe/TicTacToeGame.tsx
@@ -2,26 +2,21 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { GameStartMenu, type GameStartMenuAction } from "@/components/GameStartMenu";
 import { InGameMultiplayerOverlay, MultiplayerPanel, useMultiplayerLobby } from "@/multiplayer";
 import type { GameResetMessage, GameSpecificMessage, GameStartMessage, MultiplayerRole } from "@/multiplayer";
+import {
+  applyMove as applyTicTacToeMove,
+  chooseAiMove,
+  emptyBoard,
+  getWinResult,
+  isDraw,
+  type CellValue,
+  type PlayerSymbol,
+  type WinningLine,
+} from "./tictactoe.logic";
 import "./tictactoe.css";
 
-type CellValue = "X" | "O" | null;
-type PlayerSymbol = Exclude<CellValue, null>;
 type GameMode = "menu" | "local" | "ai" | "onlineLobby" | "online";
 type TicTacToeMoveMessage = GameSpecificMessage<"tictactoe:move", { cell: number; symbol: PlayerSymbol }>;
 type TicTacToeMessage = TicTacToeMoveMessage | GameResetMessage | GameStartMessage;
-type WinningLine = (typeof WIN_LINES)[number];
-type WinResult = { symbol: PlayerSymbol; line: WinningLine };
-
-const WIN_LINES = [
-  [0, 1, 2],
-  [3, 4, 5],
-  [6, 7, 8],
-  [0, 3, 6],
-  [1, 4, 7],
-  [2, 5, 8],
-  [0, 4, 8],
-  [2, 4, 6],
-] as const;
 
 export default function TicTacToeGame(): React.ReactElement {
   const [mode, setMode] = useState<GameMode>("menu");
@@ -35,14 +30,10 @@ export default function TicTacToeGame(): React.ReactElement {
   }, []);
 
   const applyMove = useCallback((cell: number, symbol: PlayerSymbol) => {
-    if (!Number.isInteger(cell) || cell < 0 || cell >= 9) return;
-
     setBoard((current) => {
-      if (current[cell] !== null) return current;
-      const next = current.slice();
-      next[cell] = symbol;
-      setTurn(symbol === "X" ? "O" : "X");
-      return next;
+      const result = applyTicTacToeMove(current, cell, symbol);
+      if (result.moved) setTurn(result.nextTurn);
+      return result.board;
     });
   }, []);
 
@@ -74,7 +65,7 @@ export default function TicTacToeGame(): React.ReactElement {
   const winResult = useMemo(() => getWinResult(board), [board]);
   const winner = winResult?.symbol ?? null;
   const winningLineClass = winResult ? getWinningLineClass(winResult.line) : null;
-  const draw = !winner && board.every(Boolean);
+  const draw = useMemo(() => isDraw(board), [board]);
   const onlinePlayers = 1 + lobby.remotePlayers.length;
   const onlineReady = lobby.status === "connected" && onlinePlayers >= 2;
   const myOnlineSymbol: PlayerSymbol | null = lobby.role === "host" ? "X" : lobby.role === "guest" ? "O" : null;
@@ -261,21 +252,6 @@ export default function TicTacToeGame(): React.ReactElement {
   );
 }
 
-function emptyBoard(): CellValue[] {
-  return Array<CellValue>(9).fill(null);
-}
-
-function getWinResult(board: CellValue[]): WinResult | null {
-  for (const line of WIN_LINES) {
-    const [a, b, c] = line;
-    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
-      return { symbol: board[a], line };
-    }
-  }
-
-  return null;
-}
-
 function getWinningLineClass(line: WinningLine): string {
   const key = line.join("-");
 
@@ -309,21 +285,4 @@ function getPlayerLabel(mode: GameMode, turn: PlayerSymbol, myOnlineSymbol: Play
   if (mode === "ai") return turn === "X" ? "Twój ruch" : "Ruch komputera";
   if (mode === "online") return `Twój znak: ${myOnlineSymbol ?? "brak"}`;
   return "Wybierz tryb gry";
-}
-
-function chooseAiMove(board: CellValue[], ai: PlayerSymbol, human: PlayerSymbol): number | null {
-  const firstEmptyCell = board.findIndex((value) => value === null);
-  return findWinningMove(board, ai) ?? findWinningMove(board, human) ?? (firstEmptyCell >= 0 ? firstEmptyCell : null);
-}
-
-function findWinningMove(board: CellValue[], symbol: PlayerSymbol): number | null {
-  for (const [a, b, c] of WIN_LINES) {
-    const line = [a, b, c];
-    const values = line.map((index) => board[index]);
-    if (values.filter((value) => value === symbol).length === 2 && values.includes(null)) {
-      return line[values.findIndex((value) => value === null)];
-    }
-  }
-
-  return null;
 }

--- a/src/games/tictactoe/tictactoe.logic.test.ts
+++ b/src/games/tictactoe/tictactoe.logic.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMove,
+  chooseAiMove,
+  emptyBoard,
+  findWinningMove,
+  getWinResult,
+  isDraw,
+  isLegalMove,
+  type CellValue,
+} from "./tictactoe.logic";
+
+describe("tictactoe logic", () => {
+  it("creates an empty starting board", () => {
+    expect(emptyBoard()).toEqual(Array<CellValue>(9).fill(null));
+  });
+
+  it("applies a legal move and changes the turn", () => {
+    const board = emptyBoard();
+
+    const result = applyMove(board, 4, "X");
+
+    expect(result.moved).toBe(true);
+    expect(result.board).toEqual([null, null, null, null, "X", null, null, null, null]);
+    expect(result.nextTurn).toBe("O");
+    expect(board[4]).toBeNull();
+  });
+
+  it("rejects a move on an occupied cell", () => {
+    const board = applyMove(emptyBoard(), 0, "X").board;
+
+    const result = applyMove(board, 0, "O");
+
+    expect(result.moved).toBe(false);
+    expect(result.board).toBe(board);
+    expect(result.board[0]).toBe("X");
+  });
+
+  it("rejects a move outside the board", () => {
+    const board = emptyBoard();
+
+    expect(isLegalMove(board, -1)).toBe(false);
+    expect(isLegalMove(board, 9)).toBe(false);
+    expect(applyMove(board, 9, "X").moved).toBe(false);
+  });
+
+  it.each([
+    [["X", "X", "X", null, null, null, null, null, null], [0, 1, 2]],
+    [[null, null, null, "X", "X", "X", null, null, null], [3, 4, 5]],
+    [[null, null, null, null, null, null, "X", "X", "X"], [6, 7, 8]],
+    [["X", null, null, "X", null, null, "X", null, null], [0, 3, 6]],
+    [[null, "X", null, null, "X", null, null, "X", null], [1, 4, 7]],
+    [[null, null, "X", null, null, "X", null, null, "X"], [2, 5, 8]],
+    [["X", null, null, null, "X", null, null, null, "X"], [0, 4, 8]],
+    [[null, null, "X", null, "X", null, "X", null, null], [2, 4, 6]],
+  ] as const)("detects winning line %j", (board, line) => {
+    expect(getWinResult([...board])?.line).toEqual(line);
+  });
+
+  it("detects a draw", () => {
+    const board: CellValue[] = ["X", "O", "X", "X", "O", "O", "O", "X", "X"];
+
+    expect(getWinResult(board)).toBeNull();
+    expect(isDraw(board)).toBe(true);
+  });
+
+  it("chooses a winning AI move first", () => {
+    const board: CellValue[] = ["O", "O", null, "X", null, null, "X", null, null];
+
+    expect(findWinningMove(board, "O")).toBe(2);
+    expect(chooseAiMove(board, "O", "X")).toBe(2);
+  });
+
+  it("blocks the human winning move when AI cannot win immediately", () => {
+    const board: CellValue[] = ["X", "X", null, null, "O", null, null, null, null];
+
+    expect(chooseAiMove(board, "O", "X")).toBe(2);
+  });
+
+  it("chooses the first empty cell as a fallback AI move", () => {
+    const board: CellValue[] = ["X", "O", "X", "O", null, null, null, null, null];
+
+    expect(chooseAiMove(board, "O", "X")).toBe(4);
+  });
+});

--- a/src/games/tictactoe/tictactoe.logic.ts
+++ b/src/games/tictactoe/tictactoe.logic.ts
@@ -1,0 +1,82 @@
+export type CellValue = "X" | "O" | null;
+export type PlayerSymbol = Exclude<CellValue, null>;
+
+export const WIN_LINES = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+] as const;
+
+export type WinningLine = (typeof WIN_LINES)[number];
+export type WinResult = { symbol: PlayerSymbol; line: WinningLine };
+export type MoveResult = {
+  board: CellValue[];
+  nextTurn: PlayerSymbol;
+  moved: boolean;
+};
+
+const BOARD_SIZE = 9;
+
+export function emptyBoard(): CellValue[] {
+  return Array<CellValue>(BOARD_SIZE).fill(null);
+}
+
+export function isValidCellIndex(cell: number): boolean {
+  return Number.isInteger(cell) && cell >= 0 && cell < BOARD_SIZE;
+}
+
+export function isLegalMove(board: CellValue[], cell: number): boolean {
+  return isValidCellIndex(cell) && board[cell] === null;
+}
+
+export function getNextTurn(symbol: PlayerSymbol): PlayerSymbol {
+  return symbol === "X" ? "O" : "X";
+}
+
+export function applyMove(board: CellValue[], cell: number, symbol: PlayerSymbol): MoveResult {
+  if (!isLegalMove(board, cell)) {
+    return { board, nextTurn: symbol, moved: false };
+  }
+
+  const nextBoard = board.slice();
+  nextBoard[cell] = symbol;
+
+  return { board: nextBoard, nextTurn: getNextTurn(symbol), moved: true };
+}
+
+export function getWinResult(board: CellValue[]): WinResult | null {
+  for (const line of WIN_LINES) {
+    const [a, b, c] = line;
+    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
+      return { symbol: board[a], line };
+    }
+  }
+
+  return null;
+}
+
+export function isDraw(board: CellValue[]): boolean {
+  return !getWinResult(board) && board.every(Boolean);
+}
+
+export function chooseAiMove(board: CellValue[], ai: PlayerSymbol, human: PlayerSymbol): number | null {
+  const firstEmptyCell = board.findIndex((value) => value === null);
+  return findWinningMove(board, ai) ?? findWinningMove(board, human) ?? (firstEmptyCell >= 0 ? firstEmptyCell : null);
+}
+
+export function findWinningMove(board: CellValue[], symbol: PlayerSymbol): number | null {
+  for (const [a, b, c] of WIN_LINES) {
+    const line = [a, b, c];
+    const values = line.map((index) => board[index]);
+    if (values.filter((value) => value === symbol).length === 2 && values.includes(null)) {
+      return line[values.findIndex((value) => value === null)];
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Extracted Tic Tac Toe board rules into `src/games/tictactoe/tictactoe.logic.ts`.
- Added reusable helpers for empty board creation, win detection, draw detection, legal move validation, turn switching, move application, and AI move selection.
- Added Vitest coverage for the starting board, legal and illegal moves, all winning lines, draw detection, and simple AI decisions.
- Updated `TicTacToeGame.tsx` to call the extracted logic while keeping UI and multiplayer integration in the component.

## Validation
- Static review of the changed TypeScript files and branch diff.
- Could not run `npm run verify` in this environment because direct terminal access to `github.com` is blocked, so the repository could not be cloned locally here.

Closes #161