### PR TITLE
[codex] Validate Tic Tac Toe online moves

### DIFF
--- a/src/games/tictactoe/TicTacToeGame.tsx
+++ b/src/games/tictactoe/TicTacToeGame.tsx
@@ -6,8 +6,10 @@ import {
   applyMove as applyTicTacToeMove,
   chooseAiMove,
   emptyBoard,
+  getOpponentRole,
   getWinResult,
   isDraw,
+  isLegalOnlineMove,
   type CellValue,
   type PlayerSymbol,
   type WinningLine,
@@ -22,19 +24,29 @@ export default function TicTacToeGame(): React.ReactElement {
   const [mode, setMode] = useState<GameMode>("menu");
   const [board, setBoard] = useState<CellValue[]>(() => emptyBoard());
   const [turn, setTurn] = useState<PlayerSymbol>("X");
+  const boardRef = useRef<CellValue[]>(emptyBoard());
+  const turnRef = useRef<PlayerSymbol>("X");
   const lobbyRoleRef = useRef<MultiplayerRole | null>(null);
+  const localPlayerIdRef = useRef<string | null>(null);
+  const opponentPlayerIdRef = useRef<string | null>(null);
 
   const resetBoard = useCallback(() => {
-    setBoard(emptyBoard());
+    const nextBoard = emptyBoard();
+    boardRef.current = nextBoard;
+    turnRef.current = "X";
+    setBoard(nextBoard);
     setTurn("X");
   }, []);
 
   const applyMove = useCallback((cell: number, symbol: PlayerSymbol) => {
-    setBoard((current) => {
-      const result = applyTicTacToeMove(current, cell, symbol);
-      if (result.moved) setTurn(result.nextTurn);
-      return result.board;
-    });
+    const result = applyTicTacToeMove(boardRef.current, cell, symbol);
+    if (!result.moved) return false;
+
+    boardRef.current = result.board;
+    turnRef.current = result.nextTurn;
+    setBoard(result.board);
+    setTurn(result.nextTurn);
+    return true;
   }, []);
 
   const handleRemoteMessage = useCallback(
@@ -55,7 +67,21 @@ export default function TicTacToeGame(): React.ReactElement {
       }
 
       if (message.type === "tictactoe:move") {
-        applyMove(message.cell, message.symbol);
+        const localRole = lobbyRoleRef.current;
+        if (!localRole) return;
+
+        const senderRole = getOpponentRole(localRole);
+        const isLegalRemoteMove = isLegalOnlineMove({
+          board: boardRef.current,
+          cell: message.cell,
+          symbol: message.symbol,
+          turn: turnRef.current,
+          senderRole,
+          senderId: message.senderId,
+          expectedSenderId: opponentPlayerIdRef.current,
+        });
+
+        if (isLegalRemoteMove) applyMove(message.cell, message.symbol);
       }
     },
     [applyMove, resetBoard]
@@ -76,9 +102,17 @@ export default function TicTacToeGame(): React.ReactElement {
   }, [lobby.role]);
 
   useEffect(() => {
+    localPlayerIdRef.current = lobby.localPlayer.id;
+  }, [lobby.localPlayer.id]);
+
+  useEffect(() => {
+    opponentPlayerIdRef.current = lobby.opponent?.id ?? null;
+  }, [lobby.opponent?.id]);
+
+  useEffect(() => {
     if (mode === "ai" && turn === "O" && !winner && !draw) {
       const timeoutId = window.setTimeout(() => {
-        const aiCell = chooseAiMove(board, "O", "X");
+        const aiCell = chooseAiMove(boardRef.current, "O", "X");
         if (aiCell !== null) applyMove(aiCell, "O");
       }, 320);
 
@@ -86,7 +120,7 @@ export default function TicTacToeGame(): React.ReactElement {
     }
 
     return undefined;
-  }, [applyMove, board, draw, mode, turn, winner]);
+  }, [applyMove, draw, mode, turn, winner]);
 
   const startMode = (nextMode: GameMode) => {
     resetBoard();
@@ -131,7 +165,19 @@ export default function TicTacToeGame(): React.ReactElement {
       return;
     }
 
-    if (mode === "online" && myOnlineSymbol === turn && lobby.status === "connected") {
+    if (mode === "online" && myOnlineSymbol === turn && lobby.status === "connected" && lobby.role) {
+      const isLegalLocalMove = isLegalOnlineMove({
+        board: boardRef.current,
+        cell,
+        symbol: myOnlineSymbol,
+        turn: turnRef.current,
+        senderRole: lobby.role,
+        senderId: localPlayerIdRef.current ?? undefined,
+        expectedSenderId: localPlayerIdRef.current,
+      });
+
+      if (!isLegalLocalMove) return;
+
       const sent = lobby.sendMessage({ type: "tictactoe:move", cell, symbol: myOnlineSymbol });
       if (sent) applyMove(cell, myOnlineSymbol);
     }

--- a/src/games/tictactoe/tictactoe.logic.test.ts
+++ b/src/games/tictactoe/tictactoe.logic.test.ts
@@ -4,9 +4,12 @@ import {
   chooseAiMove,
   emptyBoard,
   findWinningMove,
+  getOnlineRoleSymbol,
+  getOpponentRole,
   getWinResult,
   isDraw,
   isLegalMove,
+  isLegalOnlineMove,
   type CellValue,
 } from "./tictactoe.logic";
 
@@ -81,5 +84,78 @@ describe("tictactoe logic", () => {
     const board: CellValue[] = ["X", "O", "X", "O", null, null, null, null, null];
 
     expect(chooseAiMove(board, "O", "X")).toBe(4);
+  });
+
+  it("maps online roles to fixed symbols", () => {
+    expect(getOnlineRoleSymbol("host")).toBe("X");
+    expect(getOnlineRoleSymbol("guest")).toBe("O");
+    expect(getOpponentRole("host")).toBe("guest");
+    expect(getOpponentRole("guest")).toBe("host");
+  });
+
+  it("accepts a legal online move from the expected role and sender", () => {
+    expect(
+      isLegalOnlineMove({
+        board: emptyBoard(),
+        cell: 0,
+        symbol: "X",
+        turn: "X",
+        senderRole: "host",
+        senderId: "host-player",
+        expectedSenderId: "host-player",
+      })
+    ).toBe(true);
+  });
+
+  it("rejects online moves when symbol does not match the current turn", () => {
+    expect(
+      isLegalOnlineMove({
+        board: emptyBoard(),
+        cell: 0,
+        symbol: "X",
+        turn: "O",
+        senderRole: "host",
+      })
+    ).toBe(false);
+  });
+
+  it("rejects online moves when symbol does not match sender role", () => {
+    expect(
+      isLegalOnlineMove({
+        board: emptyBoard(),
+        cell: 0,
+        symbol: "X",
+        turn: "X",
+        senderRole: "guest",
+      })
+    ).toBe(false);
+  });
+
+  it("rejects online moves from a different sender", () => {
+    expect(
+      isLegalOnlineMove({
+        board: emptyBoard(),
+        cell: 0,
+        symbol: "O",
+        turn: "O",
+        senderRole: "guest",
+        senderId: "other-player",
+        expectedSenderId: "guest-player",
+      })
+    ).toBe(false);
+  });
+
+  it("rejects online moves after the game is finished", () => {
+    const board: CellValue[] = ["X", "X", "X", null, null, null, null, null, null];
+
+    expect(
+      isLegalOnlineMove({
+        board,
+        cell: 4,
+        symbol: "O",
+        turn: "O",
+        senderRole: "guest",
+      })
+    ).toBe(false);
   });
 });

--- a/src/games/tictactoe/tictactoe.logic.ts
+++ b/src/games/tictactoe/tictactoe.logic.ts
@@ -1,5 +1,6 @@
 export type CellValue = "X" | "O" | null;
 export type PlayerSymbol = Exclude<CellValue, null>;
+export type OnlinePlayerRole = "host" | "guest";
 
 export const WIN_LINES = [
   [0, 1, 2],
@@ -20,22 +21,61 @@ export type MoveResult = {
   moved: boolean;
 };
 
+export type OnlineMoveValidationInput = {
+  board: CellValue[];
+  cell: unknown;
+  symbol: unknown;
+  turn: PlayerSymbol;
+  senderRole: OnlinePlayerRole;
+  senderId?: string;
+  expectedSenderId?: string | null;
+};
+
 const BOARD_SIZE = 9;
 
 export function emptyBoard(): CellValue[] {
   return Array<CellValue>(BOARD_SIZE).fill(null);
 }
 
-export function isValidCellIndex(cell: number): boolean {
-  return Number.isInteger(cell) && cell >= 0 && cell < BOARD_SIZE;
+export function isPlayerSymbol(value: unknown): value is PlayerSymbol {
+  return value === "X" || value === "O";
 }
 
-export function isLegalMove(board: CellValue[], cell: number): boolean {
+export function isValidCellIndex(cell: unknown): cell is number {
+  return Number.isInteger(cell) && Number(cell) >= 0 && Number(cell) < BOARD_SIZE;
+}
+
+export function isLegalMove(board: CellValue[], cell: unknown): cell is number {
   return isValidCellIndex(cell) && board[cell] === null;
 }
 
 export function getNextTurn(symbol: PlayerSymbol): PlayerSymbol {
   return symbol === "X" ? "O" : "X";
+}
+
+export function getOnlineRoleSymbol(role: OnlinePlayerRole): PlayerSymbol {
+  return role === "host" ? "X" : "O";
+}
+
+export function getOpponentRole(role: OnlinePlayerRole): OnlinePlayerRole {
+  return role === "host" ? "guest" : "host";
+}
+
+export function isLegalOnlineMove({
+  board,
+  cell,
+  symbol,
+  turn,
+  senderRole,
+  senderId,
+  expectedSenderId,
+}: OnlineMoveValidationInput): boolean {
+  if (!isPlayerSymbol(symbol)) return false;
+  if (symbol !== turn) return false;
+  if (symbol !== getOnlineRoleSymbol(senderRole)) return false;
+  if (expectedSenderId && senderId !== expectedSenderId) return false;
+  if (getWinResult(board) || isDraw(board)) return false;
+  return isLegalMove(board, cell);
 }
 
 export function applyMove(board: CellValue[], cell: number, symbol: PlayerSymbol): MoveResult {


### PR DESCRIPTION
## Summary
- Added reusable Tic Tac Toe online move validation for turn order, sender role, fixed host/guest symbols, sender id, occupied cells, and finished games.
- Updated the online Tic Tac Toe flow to reject invalid remote move messages before mutating local board state.
- Added Vitest coverage for role-to-symbol mapping and illegal online move scenarios.

## Validation
- Reviewed the branch diff against `main` and confirmed the change is scoped to Tic Tac Toe logic, tests, and component wiring.
- Could not run `npm run verify` locally because this environment blocks direct terminal cloning/access to GitHub and does not provide `gh`.

Closes #162