### PR TITLE
[codex] Harden ESLint 9 flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import reactPlugin from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 
 const browserGlobals = {
-  AddEventListenerOptions: "readonly",
+  Audio: "readonly",
   Blob: "readonly",
   CanvasRenderingContext2D: "readonly",
   Document: "readonly",
@@ -17,10 +17,12 @@ const browserGlobals = {
   HTMLCanvasElement: "readonly",
   HTMLDivElement: "readonly",
   HTMLElement: "readonly",
+  HTMLInputElement: "readonly",
+  HTMLSelectElement: "readonly",
+  HTMLTextAreaElement: "readonly",
   Image: "readonly",
   KeyboardEvent: "readonly",
   MouseEvent: "readonly",
-  Node: "readonly",
   PointerEvent: "readonly",
   ResizeObserver: "readonly",
   StorageEvent: "readonly",
@@ -42,21 +44,36 @@ const browserGlobals = {
   window: "readonly",
 };
 
+const nodeGlobals = {
+  console: "readonly",
+  process: "readonly",
+};
+
+const vitestGlobals = {
+  afterEach: "readonly",
+  beforeEach: "readonly",
+  describe: "readonly",
+  expect: "readonly",
+  it: "readonly",
+  test: "readonly",
+  vi: "readonly",
+};
+
 export default [
   {
     ignores: [
-      "build/**",
-      "coverage/**",
-      "dist/**",
-      "legacy_backup/**",
-      "node_modules/**",
-      "playwright-report/**",
-      "public/**",
-      "storybook-static/**",
-      "test-results/**",
+      "**/dist/**",
+      "**/build/**",
+      "**/coverage/**",
+      "**/node_modules/**",
+      "**/playwright-report/**",
+      "**/storybook-static/**",
+      "**/test-results/**",
       ".cache/**",
       ".tmp/**",
       ".vite/**",
+      "legacy_backup/**",
+      "public/**",
       "temp/**",
     ],
   },
@@ -89,7 +106,6 @@ export default [
     },
     rules: {
       ...reactPlugin.configs.recommended.rules,
-      "no-empty": "warn",
       "react/jsx-uses-react": "off",
       "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",
@@ -121,9 +137,24 @@ export default [
         {
           argsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",
-          varsIgnorePattern: "^_"
-        }
+          varsIgnorePattern: "^_",
+        },
       ],
+    },
+  },
+  {
+    files: ["eslint.config.{js,mjs}", "vite.config.ts"],
+    languageOptions: {
+      globals: nodeGlobals,
+    },
+  },
+  {
+    files: ["**/*.{test,spec}.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      globals: {
+        ...browserGlobals,
+        ...vitestGlobals,
+      },
     },
   },
   prettier,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import reactPlugin from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 
 const browserGlobals = {
+  AddEventListenerOptions: "readonly",
   Audio: "readonly",
   Blob: "readonly",
   CanvasRenderingContext2D: "readonly",
@@ -23,6 +24,7 @@ const browserGlobals = {
   Image: "readonly",
   KeyboardEvent: "readonly",
   MouseEvent: "readonly",
+  Node: "readonly",
   PointerEvent: "readonly",
   ResizeObserver: "readonly",
   StorageEvent: "readonly",
@@ -106,6 +108,7 @@ export default [
     },
     rules: {
       ...reactPlugin.configs.recommended.rules,
+      "no-empty": "warn",
       "react/jsx-uses-react": "off",
       "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",


### PR DESCRIPTION
## Summary

- hardens the ESLint 9 flat config for the React + Vite + TypeScript app
- separates browser, Node/config, and Vitest globals
- keeps React, React Hooks, TypeScript, and Prettier compatibility in the flat config
- expands generated/build folder ignores without touching game code

Closes #119

## Validation

- Static review of the resulting `eslint.config.js` after pushing the branch
- Could not run `npm install` / `npm run lint` in this environment because npm registry access returns `403 Forbidden`
