### PR TITLE
[codex] Fix window drag start behavior

### DIFF
--- a/src/window/WindowManager.tsx
+++ b/src/window/WindowManager.tsx
@@ -466,6 +466,18 @@ function WindowFrame(props: {
   // Dragging
   const headerRef = React.useRef<HTMLDivElement | null>(null);
   const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const [headerEl, setHeaderEl] = useState<HTMLDivElement | null>(null);
+  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
+
+  const setHeaderRef = useCallback((node: HTMLDivElement | null) => {
+    headerRef.current = node;
+    setHeaderEl(node);
+  }, []);
+
+  const setContentRef = useCallback((node: HTMLDivElement | null) => {
+    contentRef.current = node;
+    setContentEl(node);
+  }, []);
 
   // Bind drag behavior
   useWindowDrag(
@@ -478,7 +490,7 @@ function WindowFrame(props: {
       height: w.height,
       maximized: w.maximized,
     }),
-    { headerEl: headerRef.current, contentEl: contentRef.current }
+    { headerEl, contentEl }
   );
 
   const onResizeDown = (e: React.MouseEvent) => {
@@ -513,7 +525,7 @@ function WindowFrame(props: {
     >
       <div
         className="window-header"
-        ref={headerRef}
+        ref={setHeaderRef}
         onDoubleClick={() => props.onMaximize(w.id)}
         tabIndex={0}
         aria-roledescription="Window title bar. Drag to move, double click to maximize."
@@ -564,7 +576,7 @@ function WindowFrame(props: {
       </div>
       <div
         className="window-content"
-        ref={contentRef}
+        ref={setContentRef}
         onPointerDown={() => {
           // Also focus when starting content-modifier drags on first interaction
           props.onFocus(w.id);

--- a/src/window/hooks/useWindowDrag.ts
+++ b/src/window/hooks/useWindowDrag.ts
@@ -18,12 +18,17 @@ export function useWindowDrag(
   opts?: { headerEl?: HTMLElement | null; contentEl?: HTMLElement | null }
 ): void {
   const { settings } = useSettings();
+  const patchRef = useRef(patch);
+  const getStateRef = useRef(getState);
   const dragActive = useRef(false);
   const holdTimer = useRef<number | null>(null);
   const startPoint = useRef({ x: 0, y: 0 });
   const startPos = useRef({ x: 0, y: 0 });
   const lastFrame = useRef(0);
   const pendingPos = useRef<{ x: number; y: number } | null>(null);
+
+  patchRef.current = patch;
+  getStateRef.current = getState;
 
   const threshold = Math.max(0, settings.windowDrag.startThresholdPx);
   const holdMs = Math.max(0, settings.windowDrag.holdToDragMs);
@@ -111,14 +116,14 @@ export function useWindowDrag(
         lastFrame.current = 0;
         const p = pendingPos.current;
         if (p) {
-          patch({ x: p.x, y: p.y });
+          patchRef.current({ x: p.x, y: p.y });
         }
       });
     }
   }
 
   function startDrag(e: PointerEvent) {
-    const st = getState();
+    const st = getStateRef.current();
     if (st.maximized || !settings.windowDrag.enabled || isFullscreen()) return;
 
     // Prevent text selection and focus flicker
@@ -152,7 +157,7 @@ export function useWindowDrag(
     // Prevent text selection/scroll during drag
     if (typeof (e as any).preventDefault === "function") (e as any).preventDefault();
 
-    const st = getState();
+    const st = getStateRef.current();
     if (st.maximized) return;
 
     const dx = e.clientX - startPoint.current.x;


### PR DESCRIPTION
## What changed

- Binds window drag listeners as soon as the header/content DOM nodes mount instead of waiting for a later re-render.
- Keeps the latest `patch` and `getState` callbacks in refs inside `useWindowDrag` so drag calculations use the current window position.

## Why

Dragging could require a second click because `headerRef.current` was `null` during the first render, so the pointer listener was not attached until another state update happened. Dragging could also feel like the window jumped because the listener could keep an older `getState` closure and calculate movement from a stale position.

## Validation

- Reviewed the updated `WindowManager.tsx` and `useWindowDrag.ts` through the GitHub connector.
- Local `npm run verify` could not be executed because this environment blocks terminal downloads/cloning from GitHub and `gh` is not installed.

Please let CI verify the full build/test suite on the PR.