### PR TITLE
Add emoji picker to player settings

### DIFF
--- a/src/settings/player/PlayerSettingsPanel.tsx
+++ b/src/settings/player/PlayerSettingsPanel.tsx
@@ -17,6 +17,15 @@ export type PlayerSettingsPanelProps = {
   initialFocusSelector?: string;
 };
 
+type EmojiPickerTarget = "player" | "ai";
+
+const EMOJI_OPTIONS = [
+  "😀", "😎", "🤖", "👾", "🐱", "🐶", "🦊", "🐼",
+  "🐸", "🐵", "🦄", "🐲", "🦖", "🚀", "⭐", "🔥",
+  "⚡", "💎", "🎮", "🎲", "🏆", "👑", "❤️", "💙",
+  "💚", "💛", "🟣", "❌", "⭕", "🍕", "🍩", "🍀",
+];
+
 function useFocusTrap(enabled: boolean, containerRef: React.RefObject<HTMLElement>, initialSelector?: string) {
   useEffect(() => {
     if (!enabled) return;
@@ -90,6 +99,7 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
 
   const titleId = useId();
   const descId = useId();
+  const emojiPickerTitleId = useId();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const isModal = variant === "modal" || variant === "drawer";
@@ -97,12 +107,26 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
   // Cast is safe because HTMLDivElement extends HTMLElement and our ref will be non-null during trap usage
   useFocusTrap(open && isModal, containerRef as unknown as React.RefObject<HTMLElement>, initialFocusSelector);
 
+  // Local form state with validation
+  const [name, setNameState] = useState(settings.name);
+  const [color, setColorState] = useState(settings.color);
+  const [emoji, setEmojiState] = useState(settings.emoji);
+  const [aiColor, setAiColorState] = useState(settings.aiColor);
+  const [aiEmoji, setAiEmojiState] = useState(settings.aiEmoji);
+  const [emojiPickerTarget, setEmojiPickerTarget] = useState<EmojiPickerTarget | null>(null);
+
   // Close on Escape and outside click for modal/drawer
   useEffect(() => {
     if (!open || !isModal) return;
 
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      if (emojiPickerTarget) {
+        e.preventDefault();
+        setEmojiPickerTarget(null);
+        return;
+      }
+      onClose();
     };
     const onPointer = (e: PointerEvent) => {
       if (!containerRef.current) return;
@@ -116,14 +140,7 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
       window.removeEventListener("keydown", onKey);
       containerRef.current?.removeEventListener("pointerdown", onPointer as any);
     };
-  }, [open, isModal, onClose]);
-
-  // Local form state with validation
-  const [name, setNameState] = useState(settings.name);
-  const [color, setColorState] = useState(settings.color);
-  const [emoji, setEmojiState] = useState(settings.emoji);
-  const [aiColor, setAiColorState] = useState(settings.aiColor);
-  const [aiEmoji, setAiEmojiState] = useState(settings.aiEmoji);
+  }, [open, isModal, onClose, emojiPickerTarget]);
 
   useEffect(() => {
     if (!open) return;
@@ -132,6 +149,7 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
     setEmojiState(settings.emoji);
     setAiColorState(settings.aiColor);
     setAiEmojiState(settings.aiEmoji);
+    setEmojiPickerTarget(null);
   }, [open, settings]);
 
   const invalids = useMemo(() => {
@@ -154,6 +172,8 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
   }, [name, color, emoji, aiColor, aiEmoji]);
 
   const hasErrors = Object.values(invalids).some(Boolean);
+  const currentPickerEmoji = emojiPickerTarget === "player" ? emoji : aiEmoji;
+  const currentPickerLabel = emojiPickerTarget === "player" ? "your emoji" : "AI emoji";
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -172,6 +192,16 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
     reset();
     showToast("Player settings reset");
     if (isModal) onClose();
+  };
+
+  const onEmojiSelect = (selectedEmoji: string) => {
+    if (emojiPickerTarget === "player") {
+      setEmojiState(selectedEmoji);
+    }
+    if (emojiPickerTarget === "ai") {
+      setAiEmojiState(selectedEmoji);
+    }
+    setEmojiPickerTarget(null);
   };
 
   if (!open && isModal) return null;
@@ -247,14 +277,19 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
 
             <div className="ps-field">
               <label htmlFor="ps-emoji">Emoji</label>
-              <input
+              <button
                 id="ps-emoji"
-                type="text"
-                value={emoji}
-                onChange={(e) => setEmojiState(e.target.value)}
+                type="button"
+                className="ps-emoji-trigger"
+                aria-haspopup="dialog"
+                aria-expanded={emojiPickerTarget === "player"}
                 aria-invalid={!!invalids.emoji}
                 aria-describedby={invalids.emoji ? "ps-emoji-err" : undefined}
-              />
+                onClick={() => setEmojiPickerTarget("player")}
+              >
+                <span className="ps-emoji-preview" aria-hidden>{emoji}</span>
+                <span>Choose emoji</span>
+              </button>
               {invalids.emoji && <div id="ps-emoji-err" className="ps-error" role="alert">{invalids.emoji}</div>}
             </div>
           </section>
@@ -289,14 +324,19 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
 
             <div className="ps-field">
               <label htmlFor="ps-ai-emoji">AI Emoji</label>
-              <input
+              <button
                 id="ps-ai-emoji"
-                type="text"
-                value={aiEmoji}
-                onChange={(e) => setAiEmojiState(e.target.value)}
+                type="button"
+                className="ps-emoji-trigger"
+                aria-haspopup="dialog"
+                aria-expanded={emojiPickerTarget === "ai"}
                 aria-invalid={!!invalids.aiEmoji}
                 aria-describedby={invalids.aiEmoji ? "ps-ai-emoji-err" : undefined}
-              />
+                onClick={() => setEmojiPickerTarget("ai")}
+              >
+                <span className="ps-emoji-preview" aria-hidden>{aiEmoji}</span>
+                <span>Choose emoji</span>
+              </button>
               {invalids.aiEmoji && <div id="ps-ai-emoji-err" className="ps-error" role="alert">{invalids.aiEmoji}</div>}
             </div>
           </section>
@@ -306,6 +346,45 @@ export default function PlayerSettingsPanel(props: PlayerSettingsPanelProps): Re
             <button type="button" className="ps-secondary" onClick={onReset}>Reset</button>
           </div>
         </form>
+
+        {emojiPickerTarget && (
+          <div className="ps-emoji-picker-backdrop" onPointerDown={() => setEmojiPickerTarget(null)}>
+            <div
+              className="ps-emoji-picker"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={emojiPickerTitleId}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <div className="ps-emoji-picker-header">
+                <h3 id={emojiPickerTitleId} className="ps-emoji-picker-title">Choose {currentPickerLabel}</h3>
+                <button
+                  type="button"
+                  className="ps-close"
+                  aria-label="Close emoji picker"
+                  onClick={() => setEmojiPickerTarget(null)}
+                >
+                  ×
+                </button>
+              </div>
+              <div className="ps-emoji-grid" role="listbox" aria-label={`Emoji options for ${currentPickerLabel}`}>
+                {EMOJI_OPTIONS.map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    className="ps-emoji-option"
+                    role="option"
+                    aria-label={`Choose ${option}`}
+                    aria-selected={option === currentPickerEmoji}
+                    onClick={() => onEmojiSelect(option)}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/settings/player/player-settings.css
+++ b/src/settings/player/player-settings.css
@@ -2,7 +2,7 @@
    - Modal, Drawer, and Inline variants
    - Respects site tokens from src/styles/base.css
    - Dark/light aware via data-theme
-*/
+ */
 
 .ps-panel {
   position: fixed;
@@ -175,6 +175,107 @@ html[data-theme="dark"] .ps-surface {
 }
 :root[data-theme="dark"] .ps-swatch {
   border-color: rgba(255,255,255,0.18);
+}
+
+/* Emoji picker */
+.ps-emoji-trigger {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 10px;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius-1, 6px);
+  background: var(--bg, var(--color-bg, #fff));
+  color: var(--fg, var(--color-fg, #111));
+  padding: 6px 10px;
+  cursor: pointer;
+  font-weight: 700;
+}
+.ps-emoji-trigger:hover {
+  background: rgba(0,0,0,0.04);
+}
+.ps-emoji-preview {
+  width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 8px;
+  background: rgba(0,0,0,0.06);
+  font-size: 20px;
+}
+.ps-emoji-picker-backdrop {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  background: rgba(0,0,0,0.28);
+  z-index: 1;
+}
+.ps-emoji-picker {
+  width: min(360px, 100%);
+  max-height: min(70dvh, 440px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--radius-3, 12px);
+  border: 1px solid rgba(0,0,0,0.10);
+  background: var(--bg, var(--color-bg, #fff));
+  color: var(--fg, var(--color-fg, #111));
+  box-shadow: var(--shadow-2, 0 12px 28px rgba(0,0,0,0.22));
+}
+.ps-emoji-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+}
+.ps-emoji-picker-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 800;
+}
+.ps-emoji-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
+  gap: 8px;
+  padding: 12px;
+  overflow: auto;
+}
+.ps-emoji-option {
+  min-height: 44px;
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: 10px;
+  background: rgba(0,0,0,0.03);
+  cursor: pointer;
+  font-size: 24px;
+  line-height: 1;
+}
+.ps-emoji-option:hover,
+.ps-emoji-option[aria-selected="true"] {
+  background: color-mix(in srgb, var(--accent, var(--color-accent, #2563eb)) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent, var(--color-accent, #2563eb)) 40%, transparent);
+}
+:root[data-theme="dark"] .ps-emoji-trigger,
+:root[data-theme="dark"] .ps-emoji-picker {
+  border-color: #2b3443;
+  background: rgb(20,24,32);
+  color: var(--color-fg-dark, #e5e7eb);
+}
+:root[data-theme="dark"] .ps-emoji-trigger:hover,
+:root[data-theme="dark"] .ps-emoji-preview,
+:root[data-theme="dark"] .ps-emoji-option {
+  background: rgba(255,255,255,0.08);
+}
+:root[data-theme="dark"] .ps-emoji-picker-header {
+  border-bottom-color: rgba(255,255,255,0.10);
+}
+:root[data-theme="dark"] .ps-emoji-option {
+  border-color: rgba(255,255,255,0.10);
+  color: var(--color-fg-dark, #e5e7eb);
 }
 
 /* Errors */

--- a/src/settings/player/player-settings.css
+++ b/src/settings/player/player-settings.css
@@ -32,6 +32,7 @@
 
 /* Surface */
 .ps-surface {
+  position: relative;
   width: min(560px, calc(100vw - 32px));
   max-height: min(85vh, 820px);
   display: flex;


### PR DESCRIPTION
## Summary
- replaced manual emoji text inputs with accessible picker buttons
- added a shared emoji selection modal for player and AI emoji
- added responsive light/dark styling for the picker

## Verification
- code reviewed manually in diff
- local build/test not run because the repository is only available through the GitHub connector in this session