### PR TITLE
Dodaj przesuwanie ikon pulpitu

### DIFF
--- a/src/desktop/Desktop.tsx
+++ b/src/desktop/Desktop.tsx
@@ -44,6 +44,8 @@ const parseCssPixels = (value: string): number => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
+const parseFirstCssPixel = (value: string): number => parseCssPixels(value.split(" ")[0] ?? "");
+
 const createDefaultLayout = (ids: string[]): DesktopIconLayout =>
   ids.reduce<DesktopIconLayout>((layout, id, index) => {
     layout[id] = { column: 0, row: index };
@@ -84,14 +86,16 @@ const mergeLayoutWithVisibleApps = (storedLayout: DesktopIconLayout, appIds: str
 const getGridMetrics = (gridElement: HTMLDivElement): GridMetrics => {
   const styles = window.getComputedStyle(gridElement);
   const rect = gridElement.getBoundingClientRect();
+  const iconElement = gridElement.querySelector<HTMLButtonElement>(".desktop-icon");
+  const iconRect = iconElement?.getBoundingClientRect();
 
   return {
     paddingLeft: parseCssPixels(styles.paddingLeft),
     paddingTop: parseCssPixels(styles.paddingTop),
     paddingRight: parseCssPixels(styles.paddingRight),
     paddingBottom: parseCssPixels(styles.paddingBottom),
-    iconColumn: parseCssPixels(styles.getPropertyValue("--desktop-icon-column")),
-    iconRow: parseCssPixels(styles.getPropertyValue("--desktop-icon-row")),
+    iconColumn: parseFirstCssPixel(styles.gridTemplateColumns) || iconRect?.width || 0,
+    iconRow: parseCssPixels(styles.gridAutoRows) || iconRect?.height || 0,
     gapX: parseCssPixels(styles.columnGap),
     gapY: parseCssPixels(styles.rowGap),
     viewportWidth: rect.width,

--- a/src/desktop/Desktop.tsx
+++ b/src/desktop/Desktop.tsx
@@ -1,13 +1,158 @@
-import React, { useMemo, useRef, useState, useEffect } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import "./desktop.css";
 import { useWindowManager } from "@/window/WindowManager";
 import { getAppRegistration, getDesktopApps, getWindowDefaults } from "@/window/registry";
 import ProgressiveImage from "@/components/ProgressiveImage";
 
+type DesktopIconPosition = {
+  column: number;
+  row: number;
+};
+
+type DesktopIconLayout = Record<string, DesktopIconPosition>;
+
+type GridMetrics = {
+  paddingLeft: number;
+  paddingTop: number;
+  paddingRight: number;
+  paddingBottom: number;
+  iconColumn: number;
+  iconRow: number;
+  gapX: number;
+  gapY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+};
+
+type DragState = {
+  id: string;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  offsetX: number;
+  offsetY: number;
+  hasMoved: boolean;
+  left: number;
+  top: number;
+};
+
+const DESKTOP_ICON_LAYOUT_STORAGE_KEY = "desktop.iconLayout.v1";
+const DRAG_THRESHOLD_PX = 4;
+
+const parseCssPixels = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const createDefaultLayout = (ids: string[]): DesktopIconLayout =>
+  ids.reduce<DesktopIconLayout>((layout, id, index) => {
+    layout[id] = { column: 0, row: index };
+    return layout;
+  }, {});
+
+const isIconPosition = (value: unknown): value is DesktopIconPosition => {
+  if (!value || typeof value !== "object") return false;
+  const position = value as Partial<DesktopIconPosition>;
+  return Number.isInteger(position.column) && Number.isInteger(position.row) && position.column >= 0 && position.row >= 0;
+};
+
+const readStoredLayout = (): DesktopIconLayout => {
+  if (typeof window === "undefined") return {};
+
+  try {
+    const raw = window.localStorage.getItem(DESKTOP_ICON_LAYOUT_STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return Object.entries(parsed).reduce<DesktopIconLayout>((layout, [id, position]) => {
+      if (isIconPosition(position)) layout[id] = position;
+      return layout;
+    }, {});
+  } catch {
+    return {};
+  }
+};
+
+const mergeLayoutWithVisibleApps = (storedLayout: DesktopIconLayout, appIds: string[]): DesktopIconLayout => {
+  const fallbackLayout = createDefaultLayout(appIds);
+  return appIds.reduce<DesktopIconLayout>((layout, id) => {
+    layout[id] = storedLayout[id] ?? fallbackLayout[id];
+    return layout;
+  }, {});
+};
+
+const getGridMetrics = (gridElement: HTMLDivElement): GridMetrics => {
+  const styles = window.getComputedStyle(gridElement);
+  const rect = gridElement.getBoundingClientRect();
+
+  return {
+    paddingLeft: parseCssPixels(styles.paddingLeft),
+    paddingTop: parseCssPixels(styles.paddingTop),
+    paddingRight: parseCssPixels(styles.paddingRight),
+    paddingBottom: parseCssPixels(styles.paddingBottom),
+    iconColumn: parseCssPixels(styles.getPropertyValue("--desktop-icon-column")),
+    iconRow: parseCssPixels(styles.getPropertyValue("--desktop-icon-row")),
+    gapX: parseCssPixels(styles.columnGap),
+    gapY: parseCssPixels(styles.rowGap),
+    viewportWidth: rect.width,
+    viewportHeight: rect.height,
+  };
+};
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+
+const getMaxGridPosition = (metrics: GridMetrics): DesktopIconPosition => ({
+  column: Math.max(0, Math.floor((metrics.viewportWidth - metrics.paddingLeft - metrics.paddingRight - metrics.iconColumn) / (metrics.iconColumn + metrics.gapX))),
+  row: Math.max(0, Math.floor((metrics.viewportHeight - metrics.paddingTop - metrics.paddingBottom - metrics.iconRow) / (metrics.iconRow + metrics.gapY))),
+});
+
+const getSnappedPosition = (left: number, top: number, metrics: GridMetrics): DesktopIconPosition => {
+  const maxPosition = getMaxGridPosition(metrics);
+
+  return {
+    column: clamp(Math.round((left - metrics.paddingLeft) / (metrics.iconColumn + metrics.gapX)), 0, maxPosition.column),
+    row: clamp(Math.round((top - metrics.paddingTop) / (metrics.iconRow + metrics.gapY)), 0, maxPosition.row),
+  };
+};
+
+const applyDropPosition = (layout: DesktopIconLayout, draggedId: string, nextPosition: DesktopIconPosition): DesktopIconLayout => {
+  const previousPosition = layout[draggedId];
+  const occupyingEntry = Object.entries(layout).find(
+    ([id, position]) => id !== draggedId && position.column === nextPosition.column && position.row === nextPosition.row
+  );
+
+  const nextLayout = { ...layout, [draggedId]: nextPosition };
+
+  if (occupyingEntry && previousPosition) {
+    const [occupyingId] = occupyingEntry;
+    nextLayout[occupyingId] = previousPosition;
+  }
+
+  return nextLayout;
+};
+
 export default function Desktop(): React.ReactElement {
   const { open, handles, focus } = useWindowManager();
 
   const visibleShortcuts = useMemo(() => getDesktopApps(), []);
+  const visibleShortcutIds = useMemo(() => visibleShortcuts.map((shortcut) => shortcut.id), [visibleShortcuts]);
+
+  const [iconLayout, setIconLayout] = useState<DesktopIconLayout>(() =>
+    mergeLayoutWithVisibleApps(readStoredLayout(), visibleShortcutIds)
+  );
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const suppressNextClickRef = useRef(false);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setIconLayout((currentLayout) => mergeLayoutWithVisibleApps(currentLayout, visibleShortcutIds));
+  }, [visibleShortcutIds]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(DESKTOP_ICON_LAYOUT_STORAGE_KEY, JSON.stringify(iconLayout));
+  }, [iconLayout]);
 
   const [showSettings, setShowSettings] = useState(false);
 
@@ -38,6 +183,92 @@ export default function Desktop(): React.ReactElement {
       maxWidth: def.maxWidth,
       maxHeight: def.maxHeight,
     });
+  };
+
+  const finishIconDrag = (state: DragState): void => {
+    const gridElement = gridRef.current;
+    if (!gridElement) return;
+
+    const metrics = getGridMetrics(gridElement);
+    const nextPosition = getSnappedPosition(state.left, state.top, metrics);
+    setIconLayout((currentLayout) => applyDropPosition(currentLayout, state.id, nextPosition));
+  };
+
+  const updateIconDrag = (e: React.PointerEvent<HTMLButtonElement>): void => {
+    const currentDragState = dragStateRef.current;
+    if (!currentDragState || currentDragState.pointerId !== e.pointerId) return;
+
+    const gridElement = gridRef.current;
+    if (!gridElement) return;
+
+    const gridRect = gridElement.getBoundingClientRect();
+    const metrics = getGridMetrics(gridElement);
+    const maxLeft = metrics.viewportWidth - metrics.paddingRight - metrics.iconColumn;
+    const maxTop = metrics.viewportHeight - metrics.paddingBottom - metrics.iconRow;
+    const deltaX = Math.abs(e.clientX - currentDragState.startX);
+    const deltaY = Math.abs(e.clientY - currentDragState.startY);
+    const hasMoved = currentDragState.hasMoved || deltaX > DRAG_THRESHOLD_PX || deltaY > DRAG_THRESHOLD_PX;
+
+    const nextDragState: DragState = {
+      ...currentDragState,
+      hasMoved,
+      left: clamp(e.clientX - gridRect.left - currentDragState.offsetX, metrics.paddingLeft, maxLeft),
+      top: clamp(e.clientY - gridRect.top - currentDragState.offsetY, metrics.paddingTop, maxTop),
+    };
+
+    dragStateRef.current = nextDragState;
+    setDragState(nextDragState);
+  };
+
+  const endIconDrag = (e: React.PointerEvent<HTMLButtonElement>): void => {
+    const currentDragState = dragStateRef.current;
+    if (!currentDragState || currentDragState.pointerId !== e.pointerId) return;
+
+    if (currentDragState.hasMoved) {
+      finishIconDrag(currentDragState);
+      suppressNextClickRef.current = true;
+    }
+
+    dragStateRef.current = null;
+    setDragState(null);
+
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+  };
+
+  const onIconPointerDown = (e: React.PointerEvent<HTMLButtonElement>, id: string): void => {
+    if (e.button !== 0) return;
+
+    const gridElement = gridRef.current;
+    if (!gridElement) return;
+
+    const gridRect = gridElement.getBoundingClientRect();
+    const iconRect = e.currentTarget.getBoundingClientRect();
+    const nextDragState: DragState = {
+      id,
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      offsetX: e.clientX - iconRect.left,
+      offsetY: e.clientY - iconRect.top,
+      hasMoved: false,
+      left: iconRect.left - gridRect.left,
+      top: iconRect.top - gridRect.top,
+    };
+
+    dragStateRef.current = nextDragState;
+    setDragState(nextDragState);
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const onIconClick = (id: string): void => {
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false;
+      return;
+    }
+
+    handleOpenById(id);
   };
 
   // Accessibility: roving tabindex over desktop icons
@@ -177,26 +408,42 @@ export default function Desktop(): React.ReactElement {
 
       {/* Foreground grid */}
       <div
+        ref={gridRef}
         className="desktop-grid"
         role="grid"
         aria-label="Desktop icons"
       >
-        {visibleShortcuts.map((s, i) => (
-          <button
-            ref={setIconRef(i)}
-            key={s.id}
-            className="desktop-icon"
-            data-icon={s.icon}
-            title={s.title}
-            onClick={() => handleOpenById(s.id)}
-            role="gridcell"
-            aria-label={s.title}
-            tabIndex={i === activeIndex ? 0 : -1}
-            onKeyDown={(e) => onIconKeyDown(e, i, s.id)}
-          >
-            <div className="icon-label">{s.title}</div>
-          </button>
-        ))}
+        {visibleShortcuts.map((s, i) => {
+          const position = iconLayout[s.id] ?? { column: 0, row: i };
+          const isDragging = dragState?.id === s.id && dragState.hasMoved;
+          const style: React.CSSProperties = isDragging
+            ? { left: dragState.left, top: dragState.top }
+            : { gridColumn: position.column + 1, gridRow: position.row + 1 };
+
+          return (
+            <button
+              ref={setIconRef(i)}
+              key={s.id}
+              className={`desktop-icon${isDragging ? " is-dragging" : ""}`}
+              data-icon={s.icon}
+              title={s.title}
+              style={style}
+              onClick={() => onIconClick(s.id)}
+              onPointerDown={(e) => onIconPointerDown(e, s.id)}
+              onPointerMove={updateIconDrag}
+              onPointerUp={endIconDrag}
+              onPointerCancel={endIconDrag}
+              role="gridcell"
+              aria-label={s.title}
+              aria-grabbed={isDragging}
+              tabIndex={i === activeIndex ? 0 : -1}
+              onKeyDown={(e) => onIconKeyDown(e, i, s.id)}
+              type="button"
+            >
+              <div className="icon-label">{s.title}</div>
+            </button>
+          );
+        })}
       </div>
 
       {/* Trial banner placed directly above taskbar with consistent spacing */}

--- a/src/desktop/Desktop.tsx
+++ b/src/desktop/Desktop.tsx
@@ -54,8 +54,9 @@ const createDefaultLayout = (ids: string[]): DesktopIconLayout =>
 
 const isIconPosition = (value: unknown): value is DesktopIconPosition => {
   if (!value || typeof value !== "object") return false;
-  const position = value as Partial<DesktopIconPosition>;
-  return Number.isInteger(position.column) && Number.isInteger(position.row) && position.column >= 0 && position.row >= 0;
+
+  const { column, row } = value as Partial<DesktopIconPosition>;
+  return Number.isInteger(column) && Number.isInteger(row) && typeof column === "number" && typeof row === "number" && column >= 0 && row >= 0;
 };
 
 const readStoredLayout = (): DesktopIconLayout => {

--- a/src/desktop/desktop.css
+++ b/src/desktop/desktop.css
@@ -15,12 +15,13 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
   position: relative;
   padding: clamp(var(--space-3), 3vmin, var(--space-5));
   display: grid;
-  /* Strict single column so next icon is directly under the previous one. */
-  grid-template-columns: var(--desktop-icon-column);
+  grid-template-columns: repeat(auto-fill, var(--desktop-icon-column));
   grid-auto-rows: var(--desktop-icon-row);
   gap: clamp(var(--space-3), 3vmin, var(--space-5));
   align-content: start;
   justify-content: start;
+  box-sizing: border-box;
+  user-select: none;
 }
 
 /* Icons */
@@ -33,16 +34,25 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  cursor: grab;
   position: relative;
-  transition: transform .15s ease, background .2s ease;
+  transition: transform .15s ease, background .2s ease, box-shadow .2s ease;
   backdrop-filter: blur(1.25rem);
   -webkit-backdrop-filter: blur(1.25rem);
   text-decoration: none;
   outline: none;
   color: #fff;
+  touch-action: none;
+  z-index: 1;
 }
 .desktop-icon:hover { background: rgba(255,255,255,0.2); transform: scale(1.05); }
+.desktop-icon.is-dragging {
+  position: absolute;
+  cursor: grabbing;
+  transform: scale(1.05);
+  z-index: calc(var(--z-windows) - 1);
+  box-shadow: var(--shadow-2);
+}
 .desktop-icon::before {
   content: attr(data-icon);
   font-size: var(--desktop-icon-font-size);
@@ -61,6 +71,7 @@ body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
   max-width: var(--desktop-icon-column);
   overflow: hidden;
   text-overflow: ellipsis;
+  pointer-events: none;
 }
 
 /* Taskbar */


### PR DESCRIPTION
## Co zmieniono
- Dodano przeciąganie ikon na pulpicie z użyciem Pointer Events.
- Po puszczeniu ikony pozycja snapuje się do siatki pulpitu.
- Układ ikon zapisuje się w `localStorage` pod kluczem `desktop.iconLayout.v1`.
- Przy upuszczeniu na zajętą komórkę ikonki zamieniają się miejscami.
- Kliknięcie po przeciągnięciu nie otwiera przypadkowo aplikacji.

## Weryfikacja
- Wykonany ręczny review diffu.
- Nie uruchamiałem lokalnie `npm run verify`, bo pracuję przez connector GitHub bez lokalnego środowiska repozytorium.