### PR TITLE
[codex] Add YouTube desktop app

### DIFF
--- a/src/apps/youtube/YouTubeApp.tsx
+++ b/src/apps/youtube/YouTubeApp.tsx
@@ -1,0 +1,168 @@
+import React, { FormEvent, useMemo, useState } from "react";
+import "./youtube.css";
+
+const DEFAULT_VIDEO_ID = "dQw4w9WgXcQ";
+
+type ViewMode = "player" | "search";
+
+type PlayerSource =
+  | {
+      type: "video";
+      value: string;
+      title: string;
+    }
+  | {
+      type: "search";
+      value: string;
+      title: string;
+    };
+
+const getYouTubeVideoId = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (/^[a-zA-Z0-9_-]{11}$/.test(trimmed)) return trimmed;
+
+  try {
+    const url = new URL(trimmed);
+
+    if (url.hostname.includes("youtu.be")) {
+      const id = url.pathname.split("/").filter(Boolean)[0];
+      return id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null;
+    }
+
+    if (url.hostname.includes("youtube.com")) {
+      const watchId = url.searchParams.get("v");
+      if (watchId && /^[a-zA-Z0-9_-]{11}$/.test(watchId)) return watchId;
+
+      const embedMatch = url.pathname.match(/\/embed\/([a-zA-Z0-9_-]{11})/);
+      if (embedMatch?.[1]) return embedMatch[1];
+
+      const shortsMatch = url.pathname.match(/\/shorts\/([a-zA-Z0-9_-]{11})/);
+      if (shortsMatch?.[1]) return shortsMatch[1];
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
+const buildEmbedSrc = (source: PlayerSource): string => {
+  const params = new URLSearchParams({
+    autoplay: "1",
+    rel: "0",
+    modestbranding: "1",
+  });
+
+  if (source.type === "video") {
+    return `https://www.youtube.com/embed/${source.value}?${params.toString()}`;
+  }
+
+  params.set("listType", "search");
+  params.set("list", source.value);
+  return `https://www.youtube.com/embed?${params.toString()}`;
+};
+
+export default function YouTubeApp(): React.ReactElement {
+  const [mode, setMode] = useState<ViewMode>("player");
+  const [query, setQuery] = useState("");
+  const [source, setSource] = useState<PlayerSource>({
+    type: "video",
+    value: DEFAULT_VIDEO_ID,
+    title: "YouTube",
+  });
+
+  const embedSrc = useMemo(() => buildEmbedSrc(source), [source]);
+
+  const playDefaultVideo = (): void => {
+    setSource({
+      type: "video",
+      value: DEFAULT_VIDEO_ID,
+      title: "YouTube",
+    });
+    setMode("player");
+  };
+
+  const submitSearch = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+
+    const phrase = query.trim();
+    if (!phrase) return;
+
+    const videoId = getYouTubeVideoId(phrase);
+    setSource(
+      videoId
+        ? {
+            type: "video",
+            value: videoId,
+            title: "YouTube",
+          }
+        : {
+            type: "search",
+            value: phrase,
+            title: `Wyniki: ${phrase}`,
+          }
+    );
+    setMode("player");
+  };
+
+  return (
+    <div className="youtube-app">
+      <header className="youtube-app__toolbar">
+        <button
+          className="youtube-app__nav-button"
+          type="button"
+          onClick={() => setMode(mode === "player" ? "search" : "player")}
+        >
+          {mode === "player" ? "← Wstecz" : "Odtwarzacz"}
+        </button>
+        <div className="youtube-app__brand" aria-label="YouTube">
+          <span className="youtube-app__brand-icon" aria-hidden="true">
+            ▶
+          </span>
+          <span>{source.title}</span>
+        </div>
+      </header>
+
+      {mode === "search" ? (
+        <main className="youtube-app__search-panel">
+          <div className="youtube-app__search-card">
+            <div className="youtube-app__logo" aria-hidden="true">
+              ▶
+            </div>
+            <h2>YouTube</h2>
+            <p>Wpisz frazę, link do filmu albo samo ID filmu z YouTube.</p>
+            <form className="youtube-app__search-form" onSubmit={submitSearch}>
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Szukaj albo wklej link YouTube"
+                aria-label="Szukaj w YouTube lub wklej link"
+              />
+              <button type="submit">Odtwórz</button>
+            </form>
+            <button
+              className="youtube-app__default-button"
+              type="button"
+              onClick={playDefaultVideo}
+            >
+              Wróć do domyślnego filmu
+            </button>
+          </div>
+        </main>
+      ) : (
+        <main className="youtube-app__player" aria-label="Odtwarzacz YouTube">
+          <iframe
+            key={embedSrc}
+            src={embedSrc}
+            title={source.title}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        </main>
+      )}
+    </div>
+  );
+}

--- a/src/apps/youtube/youtube.css
+++ b/src/apps/youtube/youtube.css
@@ -1,0 +1,194 @@
+.youtube-app {
+  min-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(circle at top left, rgba(255, 0, 0, 0.24), transparent 34rem),
+    linear-gradient(135deg, #111827 0%, #05070b 100%);
+  color: #f8fafc;
+  overflow: hidden;
+}
+
+.youtube-app__toolbar {
+  min-height: clamp(3rem, 9dvh, 3.75rem);
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 2vmin, 1rem);
+  padding: clamp(0.625rem, 2vmin, 0.875rem);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(5, 7, 11, 0.72);
+  backdrop-filter: blur(1rem);
+  box-sizing: border-box;
+}
+
+.youtube-app__nav-button,
+.youtube-app__search-form button,
+.youtube-app__default-button {
+  min-height: 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  padding: 0 1rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 0.16s ease,
+    background 0.16s ease,
+    border-color 0.16s ease;
+}
+
+.youtube-app__nav-button:hover,
+.youtube-app__search-form button:hover,
+.youtube-app__default-button:hover {
+  transform: translateY(-0.0625rem);
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.youtube-app__brand {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.youtube-app__brand span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.youtube-app__brand-icon,
+.youtube-app__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #ff0033;
+  color: #ffffff;
+  box-shadow: 0 1rem 2.5rem rgba(255, 0, 51, 0.3);
+}
+
+.youtube-app__brand-icon {
+  width: 2rem;
+  height: 1.375rem;
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.youtube-app__player {
+  flex: 1;
+  min-height: 0;
+  padding: clamp(0.625rem, 2vmin, 1rem);
+  box-sizing: border-box;
+}
+
+.youtube-app__player iframe {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border: 0;
+  border-radius: clamp(0.75rem, 2vmin, 1rem);
+  background: #000000;
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+}
+
+.youtube-app__search-panel {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vmin, 2rem);
+  box-sizing: border-box;
+}
+
+.youtube-app__search-card {
+  width: min(100%, 38rem);
+  display: grid;
+  justify-items: center;
+  gap: clamp(0.75rem, 2.5vmin, 1rem);
+  padding: clamp(1rem, 5vmin, 2.25rem);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: clamp(1rem, 3vmin, 1.5rem);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.3);
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.youtube-app__logo {
+  width: clamp(4rem, 14vmin, 5.5rem);
+  height: clamp(2.875rem, 10vmin, 3.875rem);
+  border-radius: 1.25rem;
+  font-size: clamp(1.5rem, 5vmin, 2.25rem);
+}
+
+.youtube-app__search-card h2 {
+  margin: 0;
+  font-size: clamp(2rem, 8vmin, 4rem);
+  line-height: 1;
+  letter-spacing: -0.07em;
+}
+
+.youtube-app__search-card p {
+  max-width: 32rem;
+  margin: 0;
+  color: rgba(248, 250, 252, 0.74);
+  line-height: 1.5;
+}
+
+.youtube-app__search-form {
+  width: 100%;
+  display: flex;
+  gap: 0.625rem;
+}
+
+.youtube-app__search-form input {
+  min-width: 0;
+  flex: 1;
+  min-height: 2.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #111827;
+  padding: 0 1rem;
+  font: inherit;
+  outline: none;
+}
+
+.youtube-app__search-form input:focus {
+  border-color: #ff6b81;
+  box-shadow: 0 0 0 0.25rem rgba(255, 0, 51, 0.22);
+}
+
+.youtube-app__search-form button {
+  background: #ff0033;
+  border-color: #ff335c;
+}
+
+.youtube-app__default-button {
+  color: rgba(255, 255, 255, 0.86);
+}
+
+@media (max-width: 36rem), (max-height: 34rem) {
+  .youtube-app__toolbar {
+    min-height: 2.75rem;
+  }
+
+  .youtube-app__search-form {
+    flex-direction: column;
+  }
+
+  .youtube-app__search-form button {
+    width: 100%;
+  }
+
+  .youtube-app__player {
+    padding: 0.5rem;
+  }
+}

--- a/src/window/registry.ts
+++ b/src/window/registry.ts
@@ -15,7 +15,7 @@ export type WindowDefaults = {
   loader: () => Promise<{ default: React.ComponentType<unknown> }>;
 };
 
-export type AppKind = "game" | "system";
+export type AppKind = "game" | "system" | "app";
 
 export type AppRegistration = {
   id: string;
@@ -69,6 +69,22 @@ export const AppRegistry: readonly AppRegistration[] = [
       x: 120,
       y: 80,
       loader: () => import("@/games/snake/SnakeGame"),
+    },
+  },
+  {
+    id: "youtube",
+    title: "YouTube",
+    icon: "▶️",
+    kind: "app",
+    implemented: true,
+    window: {
+      width: 920,
+      height: 620,
+      minWidth: 420,
+      minHeight: 360,
+      x: 180,
+      y: 90,
+      loader: () => import("@/apps/youtube/YouTubeApp"),
     },
   },
   {


### PR DESCRIPTION
## Summary

Adds a new non-game desktop app shortcut for YouTube.

## What changed

- Added `src/apps/youtube/YouTubeApp.tsx` with:
  - default playback of the requested YouTube video (`dQw4w9WgXcQ`),
  - a back button that switches to a search/start screen,
  - support for playing pasted YouTube links, shorts links, embed links, or raw video IDs,
  - search phrase handling through YouTube embed search parameters.
- Added scoped styles in `src/apps/youtube/youtube.css`.
- Registered the app as `kind: "app"` in `src/window/registry.ts`, so it appears on the desktop and opens in a managed window.

## Validation

- Manually reviewed the changed TypeScript/React and CSS files.
- Could not run local `npm run verify` because this environment receives `403 Forbidden` from npm registry while installing dependencies (`@types/react`).

## Notes

This PR is intentionally draft, as requested. Please let CI confirm the full build/test pipeline after the branch is available on GitHub.