### PR TITLE
[codex] Rename system to MINꓷOMS Xꓷ

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <!-- Include viewport-fit for safe-area support on modern mobile devices -->
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Dors XD</title>
+    <title>MINꓷOMS Xꓷ</title>
 
     <!-- Mobile support notice styles (lightweight, no layout shift) -->
     <style>

--- a/src/desktop/Desktop.tsx
+++ b/src/desktop/Desktop.tsx
@@ -453,8 +453,8 @@ export default function Desktop(): React.ReactElement {
 
       {/* License watermark styled like an inactive Windows notice. */}
       <div className="license-watermark" aria-hidden="true">
-        <div>Dors XD is not activated</div>
-        <div>Go to Settings to activate Dors XD.</div>
+        <div>MINꓷOMS Xꓷ is not activated</div>
+        <div>Go to Settings to activate MINꓷOMS Xꓷ.</div>
       </div>
 
       <div className="taskbar" role="toolbar" aria-label="Taskbar">


### PR DESCRIPTION
## What changed

- Renamed the browser page title from `Dors XD` to `MINꓷOMS Xꓷ`.
- Updated the inactive-license style desktop watermark to use `MINꓷOMS Xꓷ`.

## Why

The displayed system name should now use the new parody branding.

## Validation

- Reviewed the GitHub compare diff against `main`.
- Confirmed the branch is ahead of `main` by 2 commits and behind by 0.
- Confirmed only `index.html` and `src/desktop/Desktop.tsx` changed.

Local build/tests were not run because the terminal environment did not have a full repository checkout and direct GitHub cloning/raw download was blocked.