### PR TITLE
Fix YouTube search queries

### DIFF
--- a/src/apps/youtube/YouTubeApp.tsx
+++ b/src/apps/youtube/YouTubeApp.tsx
@@ -21,7 +21,6 @@ const DEFAULT_VIDEO_ID = "dQw4w9WgXcQ";
 type ViewMode = "player" | "search";
 
 type PlayerSource = {
-  type: "video";
   value: string;
   title: string;
 };
@@ -82,7 +81,6 @@ export default function YouTubeApp(): React.ReactElement {
   const [query, setQuery] = useState("");
   const [lastSearchUrl, setLastSearchUrl] = useState<string | null>(null);
   const [source, setSource] = useState<PlayerSource>({
-    type: "video",
     value: DEFAULT_VIDEO_ID,
     title: "YouTube",
   });
@@ -91,7 +89,6 @@ export default function YouTubeApp(): React.ReactElement {
   const embedSrc = useMemo(() => buildEmbedSrc(source), [source]);
   const shouldUsePreloadedPlayer =
     mode === "player" &&
-    source.type === "video" &&
     source.value === DEFAULT_VIDEO_ID &&
     canUsePreloadedYouTubePlayer();
 
@@ -114,7 +111,6 @@ export default function YouTubeApp(): React.ReactElement {
 
   const playDefaultVideo = (): void => {
     setSource({
-      type: "video",
       value: DEFAULT_VIDEO_ID,
       title: "YouTube",
     });
@@ -131,7 +127,6 @@ export default function YouTubeApp(): React.ReactElement {
     const videoId = getYouTubeVideoId(phrase);
     if (videoId) {
       setSource({
-        type: "video",
         value: videoId,
         title: "YouTube",
       });

--- a/src/apps/youtube/YouTubeApp.tsx
+++ b/src/apps/youtube/YouTubeApp.tsx
@@ -20,17 +20,11 @@ const DEFAULT_VIDEO_ID = "dQw4w9WgXcQ";
 
 type ViewMode = "player" | "search";
 
-type PlayerSource =
-  | {
-      type: "video";
-      value: string;
-      title: string;
-    }
-  | {
-      type: "search";
-      value: string;
-      title: string;
-    };
+type PlayerSource = {
+  type: "video";
+  value: string;
+  title: string;
+};
 
 const getYouTubeVideoId = (value: string): string | null => {
   const trimmed = value.trim();
@@ -63,8 +57,13 @@ const getYouTubeVideoId = (value: string): string | null => {
   return null;
 };
 
+const buildYouTubeSearchUrl = (phrase: string): string => {
+  const params = new URLSearchParams({ search_query: phrase });
+  return `https://www.youtube.com/results?${params.toString()}`;
+};
+
 const buildEmbedSrc = (source: PlayerSource): string => {
-  if (source.type === "video" && source.value === DEFAULT_VIDEO_ID) {
+  if (source.value === DEFAULT_VIDEO_ID) {
     return buildDefaultYouTubeSrc(false);
   }
 
@@ -75,18 +74,13 @@ const buildEmbedSrc = (source: PlayerSource): string => {
     modestbranding: "1",
   });
 
-  if (source.type === "video") {
-    return `https://www.youtube.com/embed/${source.value}?${params.toString()}`;
-  }
-
-  params.set("listType", "search");
-  params.set("list", source.value);
-  return `https://www.youtube.com/embed?${params.toString()}`;
+  return `https://www.youtube.com/embed/${source.value}?${params.toString()}`;
 };
 
 export default function YouTubeApp(): React.ReactElement {
   const [mode, setMode] = useState<ViewMode>("player");
   const [query, setQuery] = useState("");
+  const [lastSearchUrl, setLastSearchUrl] = useState<string | null>(null);
   const [source, setSource] = useState<PlayerSource>({
     type: "video",
     value: DEFAULT_VIDEO_ID,
@@ -124,6 +118,7 @@ export default function YouTubeApp(): React.ReactElement {
       value: DEFAULT_VIDEO_ID,
       title: "YouTube",
     });
+    setLastSearchUrl(null);
     setMode("player");
   };
 
@@ -134,20 +129,20 @@ export default function YouTubeApp(): React.ReactElement {
     if (!phrase) return;
 
     const videoId = getYouTubeVideoId(phrase);
-    setSource(
-      videoId
-        ? {
-            type: "video",
-            value: videoId,
-            title: "YouTube",
-          }
-        : {
-            type: "search",
-            value: phrase,
-            title: `Wyniki: ${phrase}`,
-          }
-    );
-    setMode("player");
+    if (videoId) {
+      setSource({
+        type: "video",
+        value: videoId,
+        title: "YouTube",
+      });
+      setLastSearchUrl(null);
+      setMode("player");
+      return;
+    }
+
+    const searchUrl = buildYouTubeSearchUrl(phrase);
+    setLastSearchUrl(searchUrl);
+    window.open(searchUrl, "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -180,8 +175,17 @@ export default function YouTubeApp(): React.ReactElement {
                 placeholder="Szukaj albo wklej link YouTube"
                 aria-label="Szukaj w YouTube lub wklej link"
               />
-              <button type="submit">Odtwórz</button>
+              <button type="submit">Szukaj / odtwórz</button>
             </form>
+            {lastSearchUrl && (
+              <p className="youtube-app__search-hint">
+                Wyniki wyszukiwania otworzyły się w YouTube. Jeśli nic się nie stało,
+                <a href={lastSearchUrl} target="_blank" rel="noreferrer">
+                  kliknij tutaj
+                </a>
+                .
+              </p>
+            )}
             <button
               className="youtube-app__default-button"
               type="button"

--- a/src/apps/youtube/youtube.css
+++ b/src/apps/youtube/youtube.css
@@ -137,6 +137,25 @@
   line-height: 1.5;
 }
 
+.youtube-app__search-hint {
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.youtube-app__search-hint a {
+  color: #ffffff;
+  font-weight: 800;
+  margin-left: 0.25rem;
+  text-decoration-color: rgba(255, 255, 255, 0.55);
+  text-underline-offset: 0.2em;
+}
+
+.youtube-app__search-hint a:hover {
+  text-decoration-color: #ffffff;
+}
+
 .youtube-app__search-form {
   width: 100%;
   display: flex;


### PR DESCRIPTION
## Summary
- remove deprecated YouTube embed search mode based on `listType=search`
- open plain search phrases in real YouTube search results instead of showing an unavailable-video iframe
- keep direct video IDs and YouTube links playing inside the app
- add a small fallback link when a popup is blocked

## Verification
- compared branch diff against `main`; only YouTube app component and CSS changed
- full local build was not available in this workspace because the repository could not be cloned from the terminal and the bundled archive was invalid