### PR TITLE
[codex] Fix paper soccer AI after bounce

### DIFF
--- a/src/games/paper-soccer/PaperSoccerGame.tsx
+++ b/src/games/paper-soccer/PaperSoccerGame.tsx
@@ -133,7 +133,7 @@ export default function PaperSoccerGame(): React.ReactElement {
     }, 420);
 
     return () => window.clearTimeout(timeoutId);
-  }, [applyMove, mode, state.turn, state.winner]);
+  }, [applyMove, mode, state]);
 
   const startSingle = () => {
     resetMatch();


### PR DESCRIPTION
## Problem
W grze „Piłkarzyki na kartce” komputer w trybie singleplayer zatrzymywał się po pierwszym ruchu, jeżeli ruch kończył się odbiciem.

## Przyczyna
Efekt Reacta odpowiedzialny za ruch AI zależał od `state.turn` i `state.winner`. Po odbiciu stan gry się zmieniał, ale tura nadal zostawała `away`, więc dependency array nie powodował ponownego uruchomienia efektu.

## Zmiana
Zmieniono dependency array efektu AI w `src/games/paper-soccer/PaperSoccerGame.tsx` z obserwowania wybranych pól stanu na obserwowanie całego `state`:

```tsx
}, [applyMove, mode, state]);
```

Nie zmieniano zasad gry, logiki AI ani multiplayera.

## Testy/build
- `npm install --ignore-scripts --no-audit --no-fund` zakończone powodzeniem w sandboxie.
- `npm test` uruchomione, ale zakończone błędem środowiskowym `Bus error` po starcie `vitest run`.
- `npm run build` uruchomione, ale zakończone błędem środowiskowym `Bus error` po starcie `vite build`.
- Do finalnej weryfikacji pozostaje CI na PR.