### PR TITLE
Fix desktop icon column layout

### DIFF
--- a/src/desktop/Desktop.tsx
+++ b/src/desktop/Desktop.tsx
@@ -1,16 +1,16 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import "./desktop.css";
 import { useWindowManager } from "@/window/WindowManager";
 import { getAppRegistration, getDesktopApps, getWindowDefaults } from "@/window/registry";
 import ProgressiveImage from "@/components/ProgressiveImage";
 import { useTranslation } from "@/i18n/useTranslation";
-
-type DesktopIconPosition = {
-  column: number;
-  row: number;
-};
-
-type DesktopIconLayout = Record<string, DesktopIconPosition>;
+import {
+  createDesktopIconLayout,
+  isIconPosition,
+  type DesktopIconGridDimensions,
+  type DesktopIconLayout,
+  type DesktopIconPosition,
+} from "./desktopIconLayout";
 
 type GridMetrics = {
   paddingLeft: number;
@@ -40,31 +40,6 @@ type DragState = {
 const DESKTOP_ICON_LAYOUT_STORAGE_KEY = "desktop.iconLayout.v1";
 const DRAG_THRESHOLD_PX = 4;
 
-const parseCssPixels = (value: string): number => {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
-const parseFirstCssPixel = (value: string): number => parseCssPixels(value.split(" ")[0] ?? "");
-
-const getIconPositionKey = ({ column, row }: DesktopIconPosition): string => `${column}:${row}`;
-
-const findFirstFreeIconPosition = (occupiedPositions: ReadonlySet<string>): DesktopIconPosition => {
-  for (let row = 0; row <= occupiedPositions.size; row += 1) {
-    const position = { column: 0, row };
-    if (!occupiedPositions.has(getIconPositionKey(position))) return position;
-  }
-
-  return { column: 0, row: occupiedPositions.size };
-};
-
-const isIconPosition = (value: unknown): value is DesktopIconPosition => {
-  if (!value || typeof value !== "object") return false;
-
-  const { column, row } = value as Partial<DesktopIconPosition>;
-  return Number.isInteger(column) && Number.isInteger(row) && typeof column === "number" && typeof row === "number" && column >= 0 && row >= 0;
-};
-
 const readStoredLayout = (): DesktopIconLayout => {
   if (typeof window === "undefined") return {};
 
@@ -82,21 +57,12 @@ const readStoredLayout = (): DesktopIconLayout => {
   }
 };
 
-const mergeLayoutWithVisibleApps = (storedLayout: DesktopIconLayout, appIds: string[]): DesktopIconLayout => {
-  const usedPositions = new Set<string>();
-
-  return appIds.reduce<DesktopIconLayout>((layout, id) => {
-    const storedPosition = storedLayout[id];
-    const position =
-      storedPosition && !usedPositions.has(getIconPositionKey(storedPosition))
-        ? storedPosition
-        : findFirstFreeIconPosition(usedPositions);
-
-    layout[id] = position;
-    usedPositions.add(getIconPositionKey(position));
-    return layout;
-  }, {});
+const parseCssPixels = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 };
+
+const parseFirstCssPixel = (value: string): number => parseCssPixels(value.split(" ")[0] ?? "");
 
 const getGridMetrics = (gridElement: HTMLDivElement): GridMetrics => {
   const styles = window.getComputedStyle(gridElement);
@@ -120,10 +86,18 @@ const getGridMetrics = (gridElement: HTMLDivElement): GridMetrics => {
 
 const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
 
-const getMaxGridPosition = (metrics: GridMetrics): DesktopIconPosition => ({
-  column: Math.max(0, Math.floor((metrics.viewportWidth - metrics.paddingLeft - metrics.paddingRight - metrics.iconColumn) / (metrics.iconColumn + metrics.gapX))),
-  row: Math.max(0, Math.floor((metrics.viewportHeight - metrics.paddingTop - metrics.paddingBottom - metrics.iconRow) / (metrics.iconRow + metrics.gapY))),
+const getGridDimensions = (metrics: GridMetrics): DesktopIconGridDimensions => ({
+  columns: Math.max(1, Math.floor((metrics.viewportWidth - metrics.paddingLeft - metrics.paddingRight - metrics.iconColumn) / (metrics.iconColumn + metrics.gapX)) + 1),
+  rowsPerColumn: Math.max(1, Math.floor((metrics.viewportHeight - metrics.paddingTop - metrics.paddingBottom - metrics.iconRow) / (metrics.iconRow + metrics.gapY)) + 1),
 });
+
+const getMaxGridPosition = (metrics: GridMetrics): DesktopIconPosition => {
+  const dimensions = getGridDimensions(metrics);
+  return {
+    column: dimensions.columns - 1,
+    row: dimensions.rowsPerColumn - 1,
+  };
+};
 
 const getSnappedPosition = (left: number, top: number, metrics: GridMetrics): DesktopIconPosition => {
   const maxPosition = getMaxGridPosition(metrics);
@@ -158,16 +132,49 @@ export default function Desktop(): React.ReactElement {
   const visibleShortcutIds = useMemo(() => visibleShortcuts.map((shortcut) => shortcut.id), [visibleShortcuts]);
 
   const [iconLayout, setIconLayout] = useState<DesktopIconLayout>(() =>
-    mergeLayoutWithVisibleApps(readStoredLayout(), visibleShortcutIds)
+    createDesktopIconLayout({
+      appIds: visibleShortcutIds,
+      storedLayout: readStoredLayout(),
+      gridDimensions: { rowsPerColumn: visibleShortcutIds.length || 1, columns: 1 },
+    })
   );
   const [dragState, setDragState] = useState<DragState | null>(null);
   const dragStateRef = useRef<DragState | null>(null);
   const suppressNextClickRef = useRef(false);
   const gridRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    setIconLayout((currentLayout) => mergeLayoutWithVisibleApps(currentLayout, visibleShortcutIds));
-  }, [visibleShortcutIds]);
+  const calculateLayoutForCurrentGrid = useCallback(
+    (layout: DesktopIconLayout): DesktopIconLayout => {
+      const gridElement = gridRef.current;
+
+      if (!gridElement) {
+        return createDesktopIconLayout({
+          appIds: visibleShortcutIds,
+          storedLayout: layout,
+          gridDimensions: { rowsPerColumn: visibleShortcutIds.length || 1, columns: 1 },
+        });
+      }
+
+      const metrics = getGridMetrics(gridElement);
+      return createDesktopIconLayout({
+        appIds: visibleShortcutIds,
+        storedLayout: layout,
+        gridDimensions: getGridDimensions(metrics),
+      });
+    },
+    [visibleShortcutIds]
+  );
+
+  useLayoutEffect(() => {
+    const updateLayout = (): void => {
+      setIconLayout((currentLayout) => calculateLayoutForCurrentGrid(currentLayout));
+    };
+
+    updateLayout();
+    window.addEventListener("resize", updateLayout);
+
+    return () => window.removeEventListener("resize", updateLayout);
+  }, [calculateLayoutForCurrentGrid]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;

--- a/src/desktop/desktopIconLayout.test.ts
+++ b/src/desktop/desktopIconLayout.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDesktopIconLayout,
+  getRequiredColumns,
+  hasOverlappingIconPositions,
+  type DesktopIconGridDimensions,
+} from "./desktopIconLayout";
+
+const appIds = Array.from({ length: 12 }, (_, index) => `app-${index + 1}`);
+
+const estimateGridDimensions = (viewportWidth: number, viewportHeight: number): DesktopIconGridDimensions => {
+  const taskbarHeight = 48;
+  const padding = 24;
+  const iconColumn = 72;
+  const iconRow = 72;
+  const gap = 24;
+
+  return {
+    columns: Math.max(1, Math.floor((viewportWidth - padding * 2 - iconColumn) / (iconColumn + gap)) + 1),
+    rowsPerColumn: Math.max(1, Math.floor((viewportHeight - taskbarHeight - padding * 2 - iconRow) / (iconRow + gap)) + 1),
+  };
+};
+
+describe("desktop icon layout", () => {
+  it.each([
+    [1366, 768],
+    [1920, 1080],
+    [2560, 1440],
+  ])("keeps default icons visible and non-overlapping for %ix%i", (width, height) => {
+    const gridDimensions = estimateGridDimensions(width, height);
+    const layout = createDesktopIconLayout({ appIds, gridDimensions });
+
+    expect(hasOverlappingIconPositions(layout)).toBe(false);
+    expect(getRequiredColumns(appIds.length, gridDimensions)).toBeLessThanOrEqual(gridDimensions.columns);
+
+    for (const position of Object.values(layout)) {
+      expect(position.column).toBeGreaterThanOrEqual(0);
+      expect(position.column).toBeLessThan(gridDimensions.columns);
+      expect(position.row).toBeGreaterThanOrEqual(0);
+      expect(position.row).toBeLessThan(gridDimensions.rowsPerColumn);
+    }
+  });
+
+  it("fills a column from top to bottom before moving to the next one", () => {
+    const layout = createDesktopIconLayout({
+      appIds: ["a", "b", "c", "d", "e"],
+      gridDimensions: { rowsPerColumn: 3, columns: 4 },
+    });
+
+    expect(layout).toEqual({
+      a: { column: 0, row: 0 },
+      b: { column: 0, row: 1 },
+      c: { column: 0, row: 2 },
+      d: { column: 1, row: 0 },
+      e: { column: 1, row: 1 },
+    });
+  });
+
+  it("keeps manual positions when they still fit the resized desktop", () => {
+    const layout = createDesktopIconLayout({
+      appIds: ["a", "b", "c"],
+      storedLayout: {
+        a: { column: 2, row: 1 },
+        b: { column: 0, row: 0 },
+      },
+      gridDimensions: { rowsPerColumn: 4, columns: 4 },
+    });
+
+    expect(layout.a).toEqual({ column: 2, row: 1 });
+    expect(layout.b).toEqual({ column: 0, row: 0 });
+    expect(layout.c).toEqual({ column: 0, row: 1 });
+    expect(hasOverlappingIconPositions(layout)).toBe(false);
+  });
+
+  it("reflows icons that no longer fit after resize instead of stacking them", () => {
+    const layout = createDesktopIconLayout({
+      appIds: ["a", "b", "c", "d", "e"],
+      storedLayout: {
+        a: { column: 0, row: 0 },
+        b: { column: 0, row: 1 },
+        c: { column: 0, row: 4 },
+        d: { column: 3, row: 4 },
+      },
+      gridDimensions: { rowsPerColumn: 2, columns: 2 },
+    });
+
+    expect(hasOverlappingIconPositions(layout)).toBe(false);
+    expect(layout).toEqual({
+      a: { column: 0, row: 0 },
+      b: { column: 0, row: 1 },
+      c: { column: 1, row: 0 },
+      d: { column: 1, row: 1 },
+      e: { column: 2, row: 0 },
+    });
+  });
+});

--- a/src/desktop/desktopIconLayout.ts
+++ b/src/desktop/desktopIconLayout.ts
@@ -1,0 +1,129 @@
+export type DesktopIconPosition = {
+  column: number;
+  row: number;
+};
+
+export type DesktopIconLayout = Record<string, DesktopIconPosition>;
+
+export type DesktopIconGridDimensions = {
+  rowsPerColumn: number;
+  columns: number;
+};
+
+export const getIconPositionKey = ({ column, row }: DesktopIconPosition): string => `${column}:${row}`;
+
+export const normalizeGridDimensions = (
+  dimensions: DesktopIconGridDimensions
+): DesktopIconGridDimensions => ({
+  rowsPerColumn: Math.max(1, Math.floor(dimensions.rowsPerColumn)),
+  columns: Math.max(1, Math.floor(dimensions.columns)),
+});
+
+const isInsideGrid = (
+  position: DesktopIconPosition,
+  dimensions: DesktopIconGridDimensions
+): boolean =>
+  position.column >= 0 &&
+  position.row >= 0 &&
+  position.column < dimensions.columns &&
+  position.row < dimensions.rowsPerColumn;
+
+const clampPositionToGrid = (
+  position: DesktopIconPosition,
+  dimensions: DesktopIconGridDimensions
+): DesktopIconPosition => ({
+  column: Math.min(Math.max(position.column, 0), dimensions.columns - 1),
+  row: Math.min(Math.max(position.row, 0), dimensions.rowsPerColumn - 1),
+});
+
+export const getDefaultIconPosition = (
+  index: number,
+  dimensions: Pick<DesktopIconGridDimensions, "rowsPerColumn">
+): DesktopIconPosition => {
+  const rowsPerColumn = Math.max(1, Math.floor(dimensions.rowsPerColumn));
+
+  return {
+    column: Math.floor(index / rowsPerColumn),
+    row: index % rowsPerColumn,
+  };
+};
+
+export const findFirstFreeIconPosition = (
+  occupiedPositions: ReadonlySet<string>,
+  dimensions: Pick<DesktopIconGridDimensions, "rowsPerColumn">
+): DesktopIconPosition => {
+  for (let index = 0; index <= occupiedPositions.size; index += 1) {
+    const position = getDefaultIconPosition(index, dimensions);
+    if (!occupiedPositions.has(getIconPositionKey(position))) return position;
+  }
+
+  return getDefaultIconPosition(occupiedPositions.size, dimensions);
+};
+
+export const isIconPosition = (value: unknown): value is DesktopIconPosition => {
+  if (!value || typeof value !== "object") return false;
+
+  const { column, row } = value as Partial<DesktopIconPosition>;
+  return (
+    Number.isInteger(column) &&
+    Number.isInteger(row) &&
+    typeof column === "number" &&
+    typeof row === "number" &&
+    column >= 0 &&
+    row >= 0
+  );
+};
+
+type CreateDesktopIconLayoutOptions = {
+  appIds: string[];
+  storedLayout?: DesktopIconLayout;
+  gridDimensions: DesktopIconGridDimensions;
+};
+
+export const createDesktopIconLayout = ({
+  appIds,
+  storedLayout = {},
+  gridDimensions,
+}: CreateDesktopIconLayoutOptions): DesktopIconLayout => {
+  const dimensions = normalizeGridDimensions(gridDimensions);
+  const usedPositions = new Set<string>();
+
+  return appIds.reduce<DesktopIconLayout>((layout, id) => {
+    const storedPosition = storedLayout[id];
+    const preferredPosition = storedPosition
+      ? clampPositionToGrid(storedPosition, dimensions)
+      : undefined;
+    const preferredPositionKey = preferredPosition ? getIconPositionKey(preferredPosition) : undefined;
+
+    const position =
+      preferredPosition &&
+      isInsideGrid(preferredPosition, dimensions) &&
+      preferredPositionKey &&
+      !usedPositions.has(preferredPositionKey)
+        ? preferredPosition
+        : findFirstFreeIconPosition(usedPositions, dimensions);
+
+    layout[id] = position;
+    usedPositions.add(getIconPositionKey(position));
+    return layout;
+  }, {});
+};
+
+export const getRequiredColumns = (
+  iconCount: number,
+  dimensions: Pick<DesktopIconGridDimensions, "rowsPerColumn">
+): number => {
+  const rowsPerColumn = Math.max(1, Math.floor(dimensions.rowsPerColumn));
+  return Math.max(1, Math.ceil(iconCount / rowsPerColumn));
+};
+
+export const hasOverlappingIconPositions = (layout: DesktopIconLayout): boolean => {
+  const positions = new Set<string>();
+
+  return Object.values(layout).some((position) => {
+    const key = getIconPositionKey(position);
+    if (positions.has(key)) return true;
+    positions.add(key);
+    return false;
+  });
+};


### PR DESCRIPTION
Fixes desktop icon layout so icons fill columns based on viewport height, reflow on resize, and preserve manual drag positions where possible. Verified with typecheck, lint, tests, build and verify.