### PR TITLE
feat: add Sudoku game

### DIFF
--- a/games/sudoku/sudoku.html
+++ b/games/sudoku/sudoku.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sudoku</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="../../css/common.css" rel="stylesheet">
+    <style>
+        :root {
+            --sudoku-board-size: min(86vw, 560px);
+        }
+
+        body {
+            background: radial-gradient(circle at top, #fff7d6 0, #f8f3e8 38%, #e8eef8 100%);
+            min-height: 100vh;
+        }
+
+        .sudoku-shell {
+            max-width: 980px;
+            margin: 0 auto;
+        }
+
+        .sudoku-panel {
+            background: rgba(255, 255, 255, 0.92);
+            border: 1px solid rgba(0, 0, 0, 0.08);
+            border-radius: 1.25rem;
+            box-shadow: 0 1rem 2.5rem rgba(55, 65, 81, 0.16);
+            padding: clamp(1rem, 3vw, 2rem);
+        }
+
+        #sudoku-board {
+            display: grid;
+            width: var(--sudoku-board-size);
+            height: var(--sudoku-board-size);
+            margin: 0 auto;
+            border: 3px solid #1f2937;
+            background: #1f2937;
+            gap: 1px;
+        }
+
+        .sudoku-cell {
+            border: 0;
+            background: #ffffff;
+            color: #111827;
+            font-weight: 700;
+            text-align: center;
+            cursor: pointer;
+            user-select: none;
+            transition: background-color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+        }
+
+        .sudoku-cell:hover:not(.fixed) {
+            background: #eef6ff;
+        }
+
+        .sudoku-cell.fixed {
+            background: #e8eef7;
+            color: #0f172a;
+            cursor: default;
+        }
+
+        .sudoku-cell.selected {
+            background: #d9ecff;
+            box-shadow: inset 0 0 0 3px #0d6efd;
+        }
+
+        .sudoku-cell.related {
+            background: #f1f7ff;
+        }
+
+        .sudoku-cell.invalid {
+            background: #ffe3e3;
+            color: #b42318;
+        }
+
+        .sudoku-cell.correct {
+            animation: pop 180ms ease;
+        }
+
+        .sudoku-cell.border-right-strong {
+            border-right: 2px solid #1f2937;
+        }
+
+        .sudoku-cell.border-bottom-strong {
+            border-bottom: 2px solid #1f2937;
+        }
+
+        .sudoku-cell.normal {
+            font-size: clamp(1.15rem, 5vw, 2.4rem);
+        }
+
+        .sudoku-cell.kids {
+            font-size: clamp(1.45rem, 7vw, 3rem);
+        }
+
+        .sudoku-choice {
+            min-width: 3rem;
+            min-height: 3rem;
+            font-weight: 700;
+        }
+
+        .sudoku-choice.kids {
+            font-size: 1.65rem;
+        }
+
+        .sudoku-stats {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: .75rem;
+        }
+
+        .sudoku-stat {
+            background: #f8fafc;
+            border-radius: 1rem;
+            padding: .75rem;
+            text-align: center;
+        }
+
+        .sudoku-stat strong {
+            display: block;
+            font-size: 1.2rem;
+        }
+
+        @keyframes pop {
+            0% { transform: scale(1); }
+            50% { transform: scale(1.08); }
+            100% { transform: scale(1); }
+        }
+
+        @media (max-width: 768px) {
+            .sudoku-stats {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container py-4 py-md-5 position-relative sudoku-shell">
+        <button type="button" class="btn btn-link help-button" data-bs-toggle="modal" data-bs-target="#helpModal"><i class="bi bi-question-circle"></i></button>
+        <div class="sudoku-panel">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-start gap-3 mb-4">
+                <div>
+                    <h1 class="mb-1">Sudoku</h1>
+                    <p class="text-muted mb-0">Wybierz wersję z cyframi albo łatwiejszą wersję dla dzieci ze zwierzątkami.</p>
+                </div>
+                <div class="d-flex gap-2 flex-wrap justify-content-md-end">
+                    <a href="../../index.html" class="btn btn-outline-secondary"><i class="bi bi-arrow-left"></i> Powrót</a>
+                    <button id="new-game" type="button" class="btn btn-primary"><i class="bi bi-stars"></i> Nowa gra</button>
+                </div>
+            </div>
+
+            <div class="row g-3 mb-4 align-items-end">
+                <div class="col-12 col-md-5">
+                    <label for="sudoku-mode" class="form-label">Wersja</label>
+                    <select id="sudoku-mode" class="form-select">
+                        <option value="normal">Normalna, cyfry 1-9</option>
+                        <option value="kids">Dla dzieci, zwierzątka 4x4</option>
+                    </select>
+                </div>
+                <div class="col-12 col-md-4">
+                    <label for="sudoku-difficulty" class="form-label">Poziom</label>
+                    <select id="sudoku-difficulty" class="form-select"></select>
+                </div>
+                <div class="col-12 col-md-3">
+                    <button id="check-game" type="button" class="btn btn-outline-success w-100"><i class="bi bi-check2-circle"></i> Sprawdź</button>
+                </div>
+            </div>
+
+            <div class="sudoku-stats mb-4">
+                <div class="sudoku-stat"><span class="text-muted">Wypełniono</span><strong id="filled-count">0 / 0</strong></div>
+                <div class="sudoku-stat"><span class="text-muted">Błędy</span><strong id="mistakes-count">0</strong></div>
+                <div class="sudoku-stat"><span class="text-muted">Status</span><strong id="sudoku-status">Gotowe</strong></div>
+            </div>
+
+            <div id="sudoku-board" aria-label="Plansza sudoku"></div>
+            <div id="sudoku-choices" class="d-flex flex-wrap justify-content-center gap-2 mt-4"></div>
+            <p class="text-center text-muted mt-3 mb-0">Kliknij pole, a potem wybierz symbol. Wciśnij Backspace lub Gumkę, aby wyczyścić pole.</p>
+        </div>
+
+        <div class="modal fade" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="helpModalLabel">Instrukcja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Uzupełnij puste pola tak, aby w każdym rzędzie, każdej kolumnie i każdym małym kwadracie każdy symbol pojawił się tylko raz.</p>
+                        <p>W normalnym Sudoku używasz cyfr od 1 do 9. W wersji dla dzieci plansza jest mniejsza, a cyfry zastępują zwierzątka.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="sudoku.js"></script>
+    <script src="../../js/footer.js"></script>
+</body>
+</html>

--- a/games/sudoku/sudoku.js
+++ b/games/sudoku/sudoku.js
@@ -1,0 +1,318 @@
+(() => {
+    const normalPuzzle = [
+        [0, 0, 3, 0, 2, 0, 6, 0, 0],
+        [9, 0, 0, 3, 0, 5, 0, 0, 1],
+        [0, 0, 1, 8, 0, 6, 4, 0, 0],
+        [0, 0, 8, 1, 0, 2, 9, 0, 0],
+        [7, 0, 0, 0, 0, 0, 0, 0, 8],
+        [0, 0, 6, 7, 0, 8, 2, 0, 0],
+        [0, 0, 2, 6, 0, 9, 5, 0, 0],
+        [8, 0, 0, 2, 0, 3, 0, 0, 9],
+        [0, 0, 5, 0, 1, 0, 3, 0, 0]
+    ];
+
+    const normalSolution = [
+        [4, 8, 3, 9, 2, 1, 6, 5, 7],
+        [9, 6, 7, 3, 4, 5, 8, 2, 1],
+        [2, 5, 1, 8, 7, 6, 4, 9, 3],
+        [5, 4, 8, 1, 3, 2, 9, 7, 6],
+        [7, 2, 9, 5, 6, 4, 1, 3, 8],
+        [1, 3, 6, 7, 9, 8, 2, 4, 5],
+        [3, 7, 2, 6, 8, 9, 5, 1, 4],
+        [8, 1, 4, 2, 5, 3, 7, 6, 9],
+        [6, 9, 5, 4, 1, 7, 3, 8, 2]
+    ];
+
+    const kidsPuzzle = [
+        [1, 0, 0, 4],
+        [0, 4, 1, 0],
+        [0, 1, 4, 0],
+        [4, 0, 0, 1]
+    ];
+
+    const kidsSolution = [
+        [1, 2, 3, 4],
+        [3, 4, 1, 2],
+        [2, 1, 4, 3],
+        [4, 3, 2, 1]
+    ];
+
+    const modes = {
+        normal: {
+            size: 9,
+            boxSize: 3,
+            symbols: ['1', '2', '3', '4', '5', '6', '7', '8', '9'],
+            puzzle: normalPuzzle,
+            solution: normalSolution,
+            difficulties: [
+                { label: 'Łatwy', extraHints: 10 },
+                { label: 'Normalny', extraHints: 4 },
+                { label: 'Trudniejszy', extraHints: 0 }
+            ]
+        },
+        kids: {
+            size: 4,
+            boxSize: 2,
+            symbols: ['🐶', '🐱', '🐼', '🦊'],
+            puzzle: kidsPuzzle,
+            solution: kidsSolution,
+            difficulties: [
+                { label: 'Maluch', extraHints: 4 },
+                { label: 'Prosty', extraHints: 2 },
+                { label: 'Wyzwanie', extraHints: 0 }
+            ]
+        }
+    };
+
+    const board = document.getElementById('sudoku-board');
+    const choices = document.getElementById('sudoku-choices');
+    const modeSelect = document.getElementById('sudoku-mode');
+    const difficultySelect = document.getElementById('sudoku-difficulty');
+    const newGameButton = document.getElementById('new-game');
+    const checkButton = document.getElementById('check-game');
+    const filledCount = document.getElementById('filled-count');
+    const mistakesCount = document.getElementById('mistakes-count');
+    const statusText = document.getElementById('sudoku-status');
+
+    let currentMode = modes.normal;
+    let values = [];
+    let fixed = [];
+    let selected = null;
+    let mistakes = 0;
+
+    function cloneGrid(grid) {
+        return grid.map(row => [...row]);
+    }
+
+    function getBoxStart(index) {
+        return Math.floor(index / currentMode.boxSize) * currentMode.boxSize;
+    }
+
+    function createPuzzleWithHints() {
+        const difficulty = currentMode.difficulties[Number(difficultySelect.value)] || currentMode.difficulties[0];
+        const puzzle = cloneGrid(currentMode.puzzle);
+        const emptyCells = [];
+
+        puzzle.forEach((row, rowIndex) => {
+            row.forEach((value, columnIndex) => {
+                if (value === 0) {
+                    emptyCells.push([rowIndex, columnIndex]);
+                }
+            });
+        });
+
+        shuffle(emptyCells).slice(0, difficulty.extraHints).forEach(([row, column]) => {
+            puzzle[row][column] = currentMode.solution[row][column];
+        });
+
+        return puzzle;
+    }
+
+    function shuffle(items) {
+        const result = [...items];
+        for (let index = result.length - 1; index > 0; index -= 1) {
+            const randomIndex = Math.floor(Math.random() * (index + 1));
+            [result[index], result[randomIndex]] = [result[randomIndex], result[index]];
+        }
+        return result;
+    }
+
+    function updateDifficulties() {
+        currentMode = modes[modeSelect.value];
+        difficultySelect.innerHTML = '';
+        currentMode.difficulties.forEach((difficulty, index) => {
+            const option = document.createElement('option');
+            option.value = String(index);
+            option.textContent = difficulty.label;
+            difficultySelect.appendChild(option);
+        });
+        difficultySelect.value = modeSelect.value === 'kids' ? '0' : '1';
+    }
+
+    function startGame() {
+        currentMode = modes[modeSelect.value];
+        const puzzle = createPuzzleWithHints();
+        values = cloneGrid(puzzle);
+        fixed = puzzle.map(row => row.map(value => value !== 0));
+        selected = null;
+        mistakes = 0;
+        statusText.textContent = 'Gotowe';
+        renderBoard();
+        renderChoices();
+        updateStats();
+    }
+
+    function renderBoard() {
+        board.innerHTML = '';
+        board.style.gridTemplateColumns = `repeat(${currentMode.size}, 1fr)`;
+        board.style.gridTemplateRows = `repeat(${currentMode.size}, 1fr)`;
+
+        values.forEach((row, rowIndex) => {
+            row.forEach((value, columnIndex) => {
+                const cell = document.createElement('button');
+                cell.type = 'button';
+                cell.className = `sudoku-cell ${modeSelect.value}`;
+                cell.dataset.row = String(rowIndex);
+                cell.dataset.column = String(columnIndex);
+                cell.textContent = value ? currentMode.symbols[value - 1] : '';
+                cell.setAttribute('aria-label', `Wiersz ${rowIndex + 1}, kolumna ${columnIndex + 1}`);
+
+                if (fixed[rowIndex][columnIndex]) {
+                    cell.classList.add('fixed');
+                }
+
+                if ((columnIndex + 1) % currentMode.boxSize === 0 && columnIndex < currentMode.size - 1) {
+                    cell.classList.add('border-right-strong');
+                }
+
+                if ((rowIndex + 1) % currentMode.boxSize === 0 && rowIndex < currentMode.size - 1) {
+                    cell.classList.add('border-bottom-strong');
+                }
+
+                cell.addEventListener('click', () => selectCell(rowIndex, columnIndex));
+                board.appendChild(cell);
+            });
+        });
+
+        refreshHighlights();
+    }
+
+    function renderChoices() {
+        choices.innerHTML = '';
+        currentMode.symbols.forEach((symbol, index) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = `btn btn-outline-primary sudoku-choice ${modeSelect.value}`;
+            button.textContent = symbol;
+            button.addEventListener('click', () => setSelectedValue(index + 1));
+            choices.appendChild(button);
+        });
+
+        const erase = document.createElement('button');
+        erase.type = 'button';
+        erase.className = 'btn btn-outline-secondary sudoku-choice';
+        erase.innerHTML = '<i class="bi bi-eraser"></i>';
+        erase.addEventListener('click', () => setSelectedValue(0));
+        choices.appendChild(erase);
+    }
+
+    function selectCell(row, column) {
+        selected = { row, column };
+        refreshHighlights();
+    }
+
+    function refreshHighlights() {
+        const cells = Array.from(board.querySelectorAll('.sudoku-cell'));
+        cells.forEach(cell => {
+            cell.classList.remove('selected', 'related', 'invalid');
+            const row = Number(cell.dataset.row);
+            const column = Number(cell.dataset.column);
+            const value = values[row][column];
+
+            if (selected && row === selected.row && column === selected.column) {
+                cell.classList.add('selected');
+            } else if (selected && isRelated(row, column, selected.row, selected.column)) {
+                cell.classList.add('related');
+            }
+
+            if (value !== 0 && value !== currentMode.solution[row][column]) {
+                cell.classList.add('invalid');
+            }
+        });
+    }
+
+    function isRelated(row, column, selectedRow, selectedColumn) {
+        return row === selectedRow ||
+            column === selectedColumn ||
+            (getBoxStart(row) === getBoxStart(selectedRow) && getBoxStart(column) === getBoxStart(selectedColumn));
+    }
+
+    function setSelectedValue(value) {
+        if (!selected || fixed[selected.row][selected.column]) {
+            return;
+        }
+
+        values[selected.row][selected.column] = value;
+        const cell = board.querySelector(`[data-row="${selected.row}"][data-column="${selected.column}"]`);
+        if (cell) {
+            cell.textContent = value ? currentMode.symbols[value - 1] : '';
+            cell.classList.toggle('correct', value !== 0 && value === currentMode.solution[selected.row][selected.column]);
+            setTimeout(() => cell.classList.remove('correct'), 200);
+        }
+
+        if (value !== 0 && value !== currentMode.solution[selected.row][selected.column]) {
+            mistakes += 1;
+            statusText.textContent = 'Popraw błędy';
+        }
+
+        updateStats();
+        refreshHighlights();
+        checkWin();
+    }
+
+    function updateStats() {
+        const filled = values.flat().filter(value => value !== 0).length;
+        filledCount.textContent = `${filled} / ${currentMode.size * currentMode.size}`;
+        mistakesCount.textContent = String(mistakes);
+    }
+
+    function hasErrors() {
+        return values.some((row, rowIndex) => row.some((value, columnIndex) => value !== 0 && value !== currentMode.solution[rowIndex][columnIndex]));
+    }
+
+    function isComplete() {
+        return values.every((row, rowIndex) => row.every((value, columnIndex) => value === currentMode.solution[rowIndex][columnIndex]));
+    }
+
+    function checkWin() {
+        if (isComplete()) {
+            statusText.textContent = 'Wygrana!';
+            setTimeout(() => alert('Brawo! Sudoku rozwiązane.'), 50);
+        }
+    }
+
+    function checkGame() {
+        if (isComplete()) {
+            statusText.textContent = 'Wygrana!';
+            alert('Wszystko się zgadza. Super robota!');
+            return;
+        }
+
+        if (hasErrors()) {
+            statusText.textContent = 'Są błędy';
+            alert('Na planszy są pola do poprawy. Zaznaczyłem je na czerwono.');
+            refreshHighlights();
+            return;
+        }
+
+        statusText.textContent = 'Dobrze idzie';
+        alert('Na razie nie widzę błędów. Uzupełnij resztę pól.');
+    }
+
+    document.addEventListener('keydown', event => {
+        if (!selected) {
+            return;
+        }
+
+        if (event.key === 'Backspace' || event.key === 'Delete') {
+            setSelectedValue(0);
+            return;
+        }
+
+        const digit = Number(event.key);
+        if (Number.isInteger(digit) && digit >= 1 && digit <= currentMode.size) {
+            setSelectedValue(digit);
+        }
+    });
+
+    modeSelect.addEventListener('change', () => {
+        updateDifficulties();
+        startGame();
+    });
+    difficultySelect.addEventListener('change', startGame);
+    newGameButton.addEventListener('click', startGame);
+    checkButton.addEventListener('click', checkGame);
+
+    updateDifficulties();
+    startGame();
+})();

--- a/index.html
+++ b/index.html
@@ -176,6 +176,17 @@
                         </div>
                     </div>
                 </a>
+            <a href="games/sudoku/sudoku.html" class="text-decoration-none">
+                <div class="card text-center h-100">
+                    <div class="card-body d-flex flex-column justify-content-center align-items-center">
+                        <i class="bi bi-grid-3x3" style="font-size: 3rem;"></i>
+                        <p class="mt-3 mb-0">Sudoku</p>
+                        <div class="d-flex gap-2 mt-2">
+                            <span class="badge text-bg-success"><i class="bi bi-person me-1"></i></span>
+                        </div>
+                    </div>
+                </div>
+            </a>
             </div>
         </div>
     </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -23,6 +23,7 @@
           <app-home-tile link="games/pong/pong.html" icon="bi-record-fill" title="Pong" [badges]="['people']"></app-home-tile>
           <app-home-tile link="games/hotpotato/hotpotato.html" icon="bi-fire" title="Gorący Ziemniak" [badges]="['wifi']"></app-home-tile>
           <app-home-tile link="games/cards/cards.html" icon="bi-cards" title="Ewolucja" [badges]="['person', 'wifi']"></app-home-tile>
+          <app-home-tile link="games/sudoku/sudoku.html" icon="bi-grid-3x3" title="Sudoku" [badges]="['person']"></app-home-tile>
         </div>
     </div>
     <div class="tab-pane fade" id="others" role="tabpanel" aria-labelledby="others-tab">


### PR DESCRIPTION
## Co zostało dodane
- nowa gra Sudoku dostępna z ekranu głównego
- normalna wersja 9x9 z cyframi
- uproszczona wersja dziecięca 4x4 z emoji zwierzątek
- wybór poziomu trudności, sprawdzanie planszy, podświetlanie błędów i czyszczenie pól

## Sprawdzenie
- node --check games/sudoku/sudoku.js
- podstawowe parsowanie HTML dla `games/sudoku/sudoku.html` i `src/app/home/home.component.html`

Nie merguję brancha, zgodnie z ustaleniem.