### PR TITLE
fix: restore CI pull request triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   push:
     branches:
       - main


### PR DESCRIPTION
## Co zmieniono

- Usunięto ograniczenie `pull_request.branches: [main]`, żeby CI startowało dla PR-ów niezależnie od brancha docelowego.
- Dodano jawne typy zdarzeń PR:
  - `opened`
  - `synchronize`
  - `reopened`
  - `ready_for_review`

## Dlaczego

CI mogło nie startować automatycznie, gdy PR nie był kierowany bezpośrednio do `main` albo gdy PR był utworzony jako draft i dopiero później oznaczony jako ready for review.

## Weryfikacja

- Sprawdzono aktywne workflow w repo.
- Zweryfikowano diff: zmieniony jest tylko `.github/workflows/ci.yml`.
- Nie uruchamiano lokalnego buildu, bo zmiana dotyczy wyłącznie konfiguracji GitHub Actions.