### PR TITLE
Fix YouTube embed ad noise and fallback handling

### DIFF
--- a/src/apps/youtube/YouTubeApp.tsx
+++ b/src/apps/youtube/YouTubeApp.tsx
@@ -18,8 +18,11 @@ import {
 import "./youtube.css";
 
 const DEFAULT_VIDEO_ID = "dQw4w9WgXcQ";
+const PLAYER_LOAD_TIMEOUT_MS = 8000;
+const YOUTUBE_EMBED_ORIGIN = "https://www.youtube-nocookie.com";
 
 type ViewMode = "player" | "search";
+type PlayerLoadState = "loading" | "ready" | "failed";
 
 type PlayerSource =
   | {
@@ -32,6 +35,21 @@ type PlayerSource =
       value: string;
       title: string;
     };
+
+const isBrowser = (): boolean => typeof window !== "undefined";
+
+const getOrigin = (): string =>
+  isBrowser() ? window.location.origin : "http://localhost";
+
+const buildPlayerParams = (): URLSearchParams =>
+  new URLSearchParams({
+    autoplay: "1",
+    enablejsapi: "1",
+    playsinline: "1",
+    rel: "0",
+    modestbranding: "1",
+    origin: getOrigin(),
+  });
 
 const getYouTubeVideoId = (value: string): string | null => {
   const trimmed = value.trim();
@@ -47,7 +65,10 @@ const getYouTubeVideoId = (value: string): string | null => {
       return id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null;
     }
 
-    if (url.hostname.includes("youtube.com")) {
+    if (
+      url.hostname.includes("youtube.com") ||
+      url.hostname.includes("youtube-nocookie.com")
+    ) {
       const watchId = url.searchParams.get("v");
       if (watchId && /^[a-zA-Z0-9_-]{11}$/.test(watchId)) return watchId;
 
@@ -69,26 +90,24 @@ const buildEmbedSrc = (source: PlayerSource): string => {
     return buildDefaultYouTubeSrc(false);
   }
 
-  const params = new URLSearchParams({
-    autoplay: "1",
-    playsinline: "1",
-    rel: "0",
-    modestbranding: "1",
-  });
+  const params = buildPlayerParams();
 
   if (source.type === "video") {
-    return `https://www.youtube.com/embed/${source.value}?${params.toString()}`;
+    return `${YOUTUBE_EMBED_ORIGIN}/embed/${source.value}?${params.toString()}`;
   }
 
   params.set("listType", "search");
   params.set("list", source.value);
-  return `https://www.youtube.com/embed?${params.toString()}`;
+  return `${YOUTUBE_EMBED_ORIGIN}/embed?${params.toString()}`;
 };
 
 export default function YouTubeApp(): React.ReactElement {
   const { t } = useTranslation();
   const [mode, setMode] = useState<ViewMode>("player");
   const [query, setQuery] = useState("");
+  const [playerLoadState, setPlayerLoadState] =
+    useState<PlayerLoadState>("loading");
+  const [playerReloadKey, setPlayerReloadKey] = useState(0);
   const [source, setSource] = useState<PlayerSource>({
     type: "video",
     value: DEFAULT_VIDEO_ID,
@@ -97,15 +116,31 @@ export default function YouTubeApp(): React.ReactElement {
   const playerRef = useRef<HTMLElement | null>(null);
 
   const embedSrc = useMemo(() => buildEmbedSrc(source), [source]);
+  const iframeKey = `${embedSrc}:${playerReloadKey}`;
   const shouldUsePreloadedPlayer =
     mode === "player" &&
     source.type === "video" &&
     source.value === DEFAULT_VIDEO_ID &&
+    playerReloadKey === 0 &&
     canUsePreloadedYouTubePlayer();
 
   useEffect(() => {
     startDefaultYouTubePreload();
   }, []);
+
+  useEffect(() => {
+    if (mode !== "player") return;
+
+    setPlayerLoadState("loading");
+
+    const timeout = window.setTimeout(() => {
+      setPlayerLoadState((currentState) =>
+        currentState === "loading" ? "failed" : currentState
+      );
+    }, PLAYER_LOAD_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [embedSrc, mode, playerReloadKey, shouldUsePreloadedPlayer]);
 
   useLayoutEffect(() => {
     if (!shouldUsePreloadedPlayer) {
@@ -113,9 +148,18 @@ export default function YouTubeApp(): React.ReactElement {
       return;
     }
 
-    attachDefaultYouTubePlayer(playerRef.current);
+    const attachedPlayer = attachDefaultYouTubePlayer(playerRef.current, {
+      onLoad: () => setPlayerLoadState("ready"),
+      onError: () => setPlayerLoadState("failed"),
+    });
+
+    if (!attachedPlayer.attached) {
+      setPlayerLoadState("failed");
+      return;
+    }
 
     return () => {
+      attachedPlayer.dispose();
       detachDefaultYouTubePlayer();
     };
   }, [shouldUsePreloadedPlayer]);
@@ -126,7 +170,13 @@ export default function YouTubeApp(): React.ReactElement {
       value: DEFAULT_VIDEO_ID,
       title: "YouTube",
     });
+    setPlayerReloadKey(0);
     setMode("player");
+  };
+
+  const retryPlayerLoad = (): void => {
+    setPlayerLoadState("loading");
+    setPlayerReloadKey((currentKey) => currentKey + 1);
   };
 
   const submitSearch = (event: FormEvent<HTMLFormElement>): void => {
@@ -149,6 +199,7 @@ export default function YouTubeApp(): React.ReactElement {
             title: `YouTube: ${phrase}`,
           }
     );
+    setPlayerReloadKey(0);
     setMode("player");
   };
 
@@ -211,12 +262,40 @@ export default function YouTubeApp(): React.ReactElement {
         >
           {!shouldUsePreloadedPlayer && (
             <iframe
-              key={embedSrc}
+              key={iframeKey}
               src={embedSrc}
               title={source.title}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              loading="eager"
               allowFullScreen
+              onLoad={() => setPlayerLoadState("ready")}
+              onError={() => setPlayerLoadState("failed")}
             />
+          )}
+
+          {playerLoadState === "loading" && (
+            <div className="youtube-app__player-state" aria-live="polite">
+              <div className="youtube-app__player-state-card">
+                {t("youtube.playerLoading")}
+              </div>
+            </div>
+          )}
+
+          {playerLoadState === "failed" && (
+            <div className="youtube-app__player-state" role="alert">
+              <div className="youtube-app__player-state-card">
+                <h2>{t("youtube.playerFallbackTitle")}</h2>
+                <p>{t("youtube.playerFallbackDescription")}</p>
+                <button
+                  className="youtube-app__player-retry-button"
+                  type="button"
+                  onClick={retryPlayerLoad}
+                >
+                  {t("youtube.retryPlayer")}
+                </button>
+              </div>
+            </div>
           )}
         </main>
       )}

--- a/src/apps/youtube/youtube.css
+++ b/src/apps/youtube/youtube.css
@@ -24,7 +24,8 @@
 
 .youtube-app__nav-button,
 .youtube-app__search-form button,
-.youtube-app__default-button {
+.youtube-app__default-button,
+.youtube-app__player-retry-button {
   min-height: 2.25rem;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 999px;
@@ -42,7 +43,8 @@
 
 .youtube-app__nav-button:hover,
 .youtube-app__search-form button:hover,
-.youtube-app__default-button:hover {
+.youtube-app__default-button:hover,
+.youtube-app__player-retry-button:hover {
   transform: translateY(-0.0625rem);
   background: rgba(255, 255, 255, 0.18);
   border-color: rgba(255, 255, 255, 0.28);
@@ -79,8 +81,10 @@
 }
 
 .youtube-app__player {
+  position: relative;
   flex: 1;
   min-height: 0;
+  display: grid;
   padding: clamp(0.625rem, 2vmin, 1rem);
   box-sizing: border-box;
 }
@@ -93,6 +97,47 @@
   border-radius: clamp(0.75rem, 2vmin, 1rem);
   background: #000000;
   box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+}
+
+.youtube-app__player-state {
+  position: absolute;
+  inset: clamp(0.625rem, 2vmin, 1rem);
+  display: grid;
+  place-items: center;
+  border-radius: clamp(0.75rem, 2vmin, 1rem);
+  background:
+    radial-gradient(circle at center, rgba(255, 0, 51, 0.18), transparent 60%),
+    rgba(0, 0, 0, 0.78);
+  text-align: center;
+  z-index: 1;
+}
+
+.youtube-app__player-state-card {
+  width: min(100%, 30rem);
+  display: grid;
+  justify-items: center;
+  gap: 0.75rem;
+  padding: clamp(1rem, 4vmin, 2rem);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: clamp(1rem, 3vmin, 1.5rem);
+  background: rgba(17, 24, 39, 0.86);
+  color: rgba(248, 250, 252, 0.86);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+}
+
+.youtube-app__player-state-card h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 4vmin, 2rem);
+}
+
+.youtube-app__player-state-card p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.youtube-app__player-retry-button {
+  background: #ff0033;
+  border-color: #ff335c;
 }
 
 .youtube-app__search-panel {

--- a/src/apps/youtube/youtubePreloader.ts
+++ b/src/apps/youtube/youtubePreloader.ts
@@ -2,10 +2,24 @@ const DEFAULT_YOUTUBE_VIDEO_ID = "dQw4w9WgXcQ";
 const PRELOADED_PLAYER_ID = "youtube-default-preloaded-player";
 const PRELOADED_PLAYER_WIDTH = 320;
 const PRELOADED_PLAYER_HEIGHT = 180;
+const YOUTUBE_EMBED_ORIGIN = "https://www.youtube-nocookie.com";
+
+export type YouTubePlayerLoadState = "idle" | "loading" | "ready" | "failed";
+
+type AttachDefaultYouTubePlayerCallbacks = {
+  onLoad?: () => void;
+  onError?: () => void;
+};
+
+type AttachedDefaultYouTubePlayer = {
+  attached: boolean;
+  dispose: () => void;
+};
 
 let preloadedIframe: HTMLIFrameElement | null = null;
 let hiddenHost: HTMLDivElement | null = null;
 let deferredPreloadStarted = false;
+let preloadedIframeLoadState: YouTubePlayerLoadState = "idle";
 
 const isBrowser = (): boolean =>
   typeof window !== "undefined" && typeof document !== "undefined";
@@ -36,7 +50,7 @@ export const buildDefaultYouTubeSrc = (muted: boolean): string => {
     params.set("mute", "1");
   }
 
-  return `https://www.youtube.com/embed/${DEFAULT_YOUTUBE_VIDEO_ID}?${params.toString()}`;
+  return `${YOUTUBE_EMBED_ORIGIN}/embed/${DEFAULT_YOUTUBE_VIDEO_ID}?${params.toString()}`;
 };
 
 const createHiddenHost = (): HTMLDivElement | null => {
@@ -92,12 +106,8 @@ const postPlayerCommand = (
   args: Array<number | boolean> = []
 ): void => {
   iframe.contentWindow?.postMessage(
-    JSON.stringify({
-      event: "command",
-      func,
-      args,
-    }),
-    "https://www.youtube.com"
+    JSON.stringify({ event: "command", func, args }),
+    YOUTUBE_EMBED_ORIGIN
   );
 };
 
@@ -111,10 +121,8 @@ const wakeDefaultPlayer = (iframe: HTMLIFrameElement): void => {
 export const startDefaultYouTubePreload = (): void => {
   if (!isBrowser() || preloadedIframe) return;
 
-  ensurePreconnect("https://www.youtube.com");
+  ensurePreconnect(YOUTUBE_EMBED_ORIGIN);
   ensurePreconnect("https://i.ytimg.com");
-  ensurePreconnect("https://www.google.com");
-  ensurePreconnect("https://googleads.g.doubleclick.net");
 
   hiddenHost = createHiddenHost();
   if (!hiddenHost) {
@@ -132,22 +140,52 @@ export const startDefaultYouTubePreload = (): void => {
   iframe.title = "YouTube";
   iframe.src = buildDefaultYouTubeSrc(true);
   iframe.setAttribute("loading", "eager");
+  iframe.setAttribute("referrerpolicy", "strict-origin-when-cross-origin");
   iframe.allow =
     "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share";
   iframe.setAttribute("allowfullscreen", "true");
+  iframe.addEventListener("load", () => {
+    preloadedIframeLoadState = "ready";
+  });
+  iframe.addEventListener("error", () => {
+    preloadedIframeLoadState = "failed";
+  });
 
   prepareIframeForHiddenPreload(iframe);
   hiddenHost.appendChild(iframe);
   preloadedIframe = iframe;
+  preloadedIframeLoadState = "loading";
 };
 
 export const attachDefaultYouTubePlayer = (
-  target: HTMLElement | null
-): boolean => {
-  if (!isBrowser() || !target) return false;
+  target: HTMLElement | null,
+  callbacks: AttachDefaultYouTubePlayerCallbacks = {}
+): AttachedDefaultYouTubePlayer => {
+  if (!isBrowser() || !target) {
+    return { attached: false, dispose: () => undefined };
+  }
 
   startDefaultYouTubePreload();
-  if (!preloadedIframe) return false;
+  if (!preloadedIframe) {
+    return { attached: false, dispose: () => undefined };
+  }
+
+  let disposed = false;
+  const handleLoad = (): void => {
+    if (!disposed) callbacks.onLoad?.();
+  };
+  const handleError = (): void => {
+    if (!disposed) callbacks.onError?.();
+  };
+
+  if (preloadedIframeLoadState === "ready") {
+    callbacks.onLoad?.();
+  } else if (preloadedIframeLoadState === "failed") {
+    callbacks.onError?.();
+  } else {
+    preloadedIframe.addEventListener("load", handleLoad, { once: true });
+    preloadedIframe.addEventListener("error", handleError, { once: true });
+  }
 
   prepareIframeForPlayer(preloadedIframe);
   target.textContent = "";
@@ -165,7 +203,14 @@ export const attachDefaultYouTubePlayer = (
     }
   }, 750);
 
-  return true;
+  return {
+    attached: true,
+    dispose: () => {
+      disposed = true;
+      preloadedIframe?.removeEventListener("load", handleLoad);
+      preloadedIframe?.removeEventListener("error", handleError);
+    },
+  };
 };
 
 export const detachDefaultYouTubePlayer = (): void => {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -458,6 +458,10 @@ const translations: Record<Language, Record<string, string>> = {
     "youtube.searchHintLink": "kliknij tutaj",
     "youtube.defaultVideo": "Wróć do domyślnego filmu",
     "youtube.playerAria": "Odtwarzacz YouTube",
+    "youtube.playerLoading": "Ładowanie odtwarzacza…",
+    "youtube.playerFallbackTitle": "Nie udało się załadować odtwarzacza",
+    "youtube.playerFallbackDescription": "YouTube albo część jego zasobów jest blokowana przez DNS/adblock. Sama aplikacja działa dalej, możesz spróbować ponownie albo wyszukać inny film.",
+    "youtube.retryPlayer": "Spróbuj ponownie",
 
     "multiplayer.title": "Gra online",
     "multiplayer.subtitle": "Utwórz pokój albo dołącz kodem od hosta.",
@@ -948,6 +952,10 @@ const translations: Record<Language, Record<string, string>> = {
     "youtube.searchHintLink": "click here",
     "youtube.defaultVideo": "Back to default video",
     "youtube.playerAria": "YouTube player",
+    "youtube.playerLoading": "Loading the player…",
+    "youtube.playerFallbackTitle": "The player could not be loaded",
+    "youtube.playerFallbackDescription": "YouTube or some of its resources may be blocked by DNS/adblock. The app is still running, so you can try again or search for another video.",
+    "youtube.retryPlayer": "Try again",
 
     "multiplayer.title": "Online game",
     "multiplayer.subtitle": "Create a room or join with a host code.",


### PR DESCRIPTION
## Summary
- Switch YouTube embeds and the default-video preloader to `youtube-nocookie.com`.
- Keep explicit player params: `autoplay`, `playsinline`, `rel`, `modestbranding`, `enablejsapi`, `origin`.
- Remove app-created preconnects to Google/ad domains that were contributing to DNS/adblock console noise.
- Add a local loading/error fallback UI with retry for the iframe/player.
- Do not globally silence `console.error` or hide real application errors.

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅ passes with existing warnings, 0 errors
- `npm test` ✅ 9 files, 70 tests
- `npm run build` ✅

Not merged by request.