### PR TITLE
Zabezpiecz aplikację YouTube przed wychodzeniem poza desktop

### DIFF
--- a/src/apps/youtube/YouTubeApp.tsx
+++ b/src/apps/youtube/YouTubeApp.tsx
@@ -9,6 +9,11 @@ import React, {
 import youtubeIcon from "@/assets/brand-icons/youtube.svg";
 import { useTranslation } from "@/i18n/useTranslation";
 import {
+  YOUTUBE_IFRAME_ALLOW,
+  YOUTUBE_IFRAME_REFERRER_POLICY,
+  YOUTUBE_IFRAME_SANDBOX,
+} from "./youtubeIframePolicy";
+import {
   attachDefaultYouTubePlayer,
   buildDefaultYouTubeSrc,
   canUsePreloadedYouTubePlayer,
@@ -265,8 +270,9 @@ export default function YouTubeApp(): React.ReactElement {
               key={iframeKey}
               src={embedSrc}
               title={source.title}
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              referrerPolicy="strict-origin-when-cross-origin"
+              allow={YOUTUBE_IFRAME_ALLOW}
+              referrerPolicy={YOUTUBE_IFRAME_REFERRER_POLICY}
+              sandbox={YOUTUBE_IFRAME_SANDBOX}
               loading="eager"
               allowFullScreen
               onLoad={() => setPlayerLoadState("ready")}

--- a/src/apps/youtube/youtubeIframePolicy.test.ts
+++ b/src/apps/youtube/youtubeIframePolicy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  YOUTUBE_IFRAME_ALLOW,
+  YOUTUBE_IFRAME_REFERRER_POLICY,
+  YOUTUBE_IFRAME_SANDBOX,
+  YOUTUBE_IFRAME_SANDBOX_TOKENS,
+} from "./youtubeIframePolicy";
+
+const blockedSandboxTokens = [
+  "allow-popups",
+  "allow-popups-to-escape-sandbox",
+  "allow-top-navigation",
+  "allow-top-navigation-by-user-activation",
+];
+
+describe("YouTube iframe policy", () => {
+  it("blocks popups and top-level navigation by omitting dangerous sandbox tokens", () => {
+    const sandboxTokens = YOUTUBE_IFRAME_SANDBOX.split(/\s+/);
+
+    expect(sandboxTokens).toEqual([...YOUTUBE_IFRAME_SANDBOX_TOKENS]);
+    expect(sandboxTokens).toEqual(
+      expect.arrayContaining([
+        "allow-scripts",
+        "allow-same-origin",
+        "allow-presentation",
+      ])
+    );
+
+    for (const blockedToken of blockedSandboxTokens) {
+      expect(sandboxTokens).not.toContain(blockedToken);
+    }
+  });
+
+  it("keeps the permissions needed for embedded video playback without share or clipboard features", () => {
+    const allowFeatures = YOUTUBE_IFRAME_ALLOW.split(";").map((feature) =>
+      feature.trim()
+    );
+
+    expect(allowFeatures).toEqual(
+      expect.arrayContaining([
+        "accelerometer",
+        "autoplay",
+        "encrypted-media",
+        "fullscreen",
+        "gyroscope",
+        "picture-in-picture",
+      ])
+    );
+    expect(allowFeatures).not.toContain("clipboard-write");
+    expect(allowFeatures).not.toContain("web-share");
+    expect(YOUTUBE_IFRAME_REFERRER_POLICY).toBe(
+      "strict-origin-when-cross-origin"
+    );
+  });
+});

--- a/src/apps/youtube/youtubeIframePolicy.ts
+++ b/src/apps/youtube/youtubeIframePolicy.ts
@@ -1,0 +1,18 @@
+export const YOUTUBE_IFRAME_ALLOW = [
+  "accelerometer",
+  "autoplay",
+  "encrypted-media",
+  "fullscreen",
+  "gyroscope",
+  "picture-in-picture",
+].join("; ");
+
+export const YOUTUBE_IFRAME_SANDBOX_TOKENS = [
+  "allow-scripts",
+  "allow-same-origin",
+  "allow-presentation",
+] as const;
+
+export const YOUTUBE_IFRAME_SANDBOX = YOUTUBE_IFRAME_SANDBOX_TOKENS.join(" ");
+
+export const YOUTUBE_IFRAME_REFERRER_POLICY = "strict-origin-when-cross-origin";

--- a/src/apps/youtube/youtubePreloader.ts
+++ b/src/apps/youtube/youtubePreloader.ts
@@ -144,7 +144,6 @@ export const startDefaultYouTubePreload = (): void => {
   const iframe = document.createElement("iframe");
   iframe.id = PRELOADED_PLAYER_ID;
   iframe.title = "YouTube";
-  iframe.src = buildDefaultYouTubeSrc(true);
   iframe.setAttribute("loading", "eager");
   iframe.setAttribute("referrerpolicy", YOUTUBE_IFRAME_REFERRER_POLICY);
   iframe.setAttribute("sandbox", YOUTUBE_IFRAME_SANDBOX);
@@ -158,6 +157,7 @@ export const startDefaultYouTubePreload = (): void => {
   });
 
   prepareIframeForHiddenPreload(iframe);
+  iframe.src = buildDefaultYouTubeSrc(true);
   hiddenHost.appendChild(iframe);
   preloadedIframe = iframe;
   preloadedIframeLoadState = "loading";

--- a/src/apps/youtube/youtubePreloader.ts
+++ b/src/apps/youtube/youtubePreloader.ts
@@ -1,3 +1,9 @@
+import {
+  YOUTUBE_IFRAME_ALLOW,
+  YOUTUBE_IFRAME_REFERRER_POLICY,
+  YOUTUBE_IFRAME_SANDBOX,
+} from "./youtubeIframePolicy";
+
 const DEFAULT_YOUTUBE_VIDEO_ID = "dQw4w9WgXcQ";
 const PRELOADED_PLAYER_ID = "youtube-default-preloaded-player";
 const PRELOADED_PLAYER_WIDTH = 320;
@@ -140,9 +146,9 @@ export const startDefaultYouTubePreload = (): void => {
   iframe.title = "YouTube";
   iframe.src = buildDefaultYouTubeSrc(true);
   iframe.setAttribute("loading", "eager");
-  iframe.setAttribute("referrerpolicy", "strict-origin-when-cross-origin");
-  iframe.allow =
-    "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share";
+  iframe.setAttribute("referrerpolicy", YOUTUBE_IFRAME_REFERRER_POLICY);
+  iframe.setAttribute("sandbox", YOUTUBE_IFRAME_SANDBOX);
+  iframe.allow = YOUTUBE_IFRAME_ALLOW;
   iframe.setAttribute("allowfullscreen", "true");
   iframe.addEventListener("load", () => {
     preloadedIframeLoadState = "ready";


### PR DESCRIPTION
## Co zmieniono
- Dodałem wspólną politykę iframe dla aplikacji YouTube: `allow`, `sandbox` i `referrerPolicy` są trzymane w jednym miejscu.
- Dodałem `sandbox="allow-scripts allow-same-origin allow-presentation"` dla normalnego oraz preloadowanego iframe YouTube.
- Celowo nie dodaję tokenów `allow-popups`, `allow-popups-to-escape-sandbox`, `allow-top-navigation` ani `allow-top-navigation-by-user-activation`, aby kliknięcia z iframe nie mogły otwierać nowych kart ani nawigować całego wirtualnego desktopu.
- Ograniczyłem `allow` do funkcji potrzebnych do odtwarzania: autoplay, encrypted-media, fullscreen, picture-in-picture itd. Usunąłem `clipboard-write` i `web-share`.
- Dodałem test jednostkowy pilnujący, że polityka iframe nie dopuszcza popupów ani top-level navigation.

## Ważne ograniczenie
YouTube działa jako zewnętrzny, cross-origin iframe. Aplikacja nie ma pełnej kontroli nad requestami wykonywanymi wewnątrz iframe, więc requesty do domen reklamowych Google mogą nadal pojawiać się w DevTools, szczególnie gdy DNS/adblock je blokuje. Ten PR ogranicza bezpiecznie to, co możemy kontrolować po stronie hosta: uprawnienia iframe, możliwość popupów i możliwość przejęcia nawigacji całego desktopu.

## Testy wykonane
- [x] `npm test` — 72 testy przeszły
- [x] `npm run build` — build przeszedł
- [x] `npm run typecheck` — przeszedł

## Ręczna checklista
- [ ] Otworzyć aplikację YouTube z pulpitu i sprawdzić, czy domyślny film nadal odtwarza się w oknie.
- [ ] Wyszukać frazę w aplikacji YouTube i potwierdzić, że wynik/odtwarzanie zostaje w oknie aplikacji.
- [ ] Kliknąć elementy wewnątrz iframe, które normalnie próbują otworzyć zewnętrzny link lub reklamę, i potwierdzić, że nie otwierają nowej karty oraz nie nawigują całego desktopu.
- [ ] Przy blokowanych domenach reklamowych potwierdzić, że aplikacja YouTube nie crashuje.
- [ ] Sprawdzić fullscreen / picture-in-picture, jeżeli przeglądarka i embed YouTube na to pozwalają.