### PR TITLE
feat: add /cc shortcut for Countries Cities

### DIFF
--- a/src/direct/DirectGameRoute.tsx
+++ b/src/direct/DirectGameRoute.tsx
@@ -5,6 +5,7 @@ import {
   type WindowDefaults,
 } from "@/window/registry";
 import { useTranslation } from "@/i18n/useTranslation";
+import { resolveDirectGameRouteAppId } from "./directGameRouteAliases";
 import "./direct-game-route.css";
 
 type DirectGameRouteProps = {
@@ -50,7 +51,8 @@ export function getDirectGameIdFromPathname(
 
   if (routeSegments.length !== 1) return undefined;
 
-  const appId = safelyDecodePathSegment(routeSegments[0] ?? "");
+  const routeAppId = safelyDecodePathSegment(routeSegments[0] ?? "");
+  const appId = resolveDirectGameRouteAppId(routeAppId);
   const app = getAppRegistration(appId);
   return isDirectGameRegistration(app) ? app.id : undefined;
 }

--- a/src/direct/directGameRouteAliases.test.ts
+++ b/src/direct/directGameRouteAliases.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDirectGameRouteAppId } from "./directGameRouteAliases";
+
+describe("resolveDirectGameRouteAppId", () => {
+  it("keeps regular app ids unchanged", () => {
+    expect(resolveDirectGameRouteAppId("countries-cities")).toBe("countries-cities");
+  });
+
+  it("maps cc to countries-cities", () => {
+    expect(resolveDirectGameRouteAppId("cc")).toBe("countries-cities");
+  });
+
+  it("matches shortcut case-insensitively and ignores extra whitespace", () => {
+    expect(resolveDirectGameRouteAppId(" CC ")).toBe("countries-cities");
+  });
+});

--- a/src/direct/directGameRouteAliases.ts
+++ b/src/direct/directGameRouteAliases.ts
@@ -1,0 +1,8 @@
+const DIRECT_GAME_ROUTE_ALIASES: Readonly<Record<string, string>> = {
+  cc: "countries-cities",
+};
+
+export function resolveDirectGameRouteAppId(routeSegment: string): string {
+  const normalizedSegment = routeSegment.trim().toLowerCase();
+  return DIRECT_GAME_ROUTE_ALIASES[normalizedSegment] ?? routeSegment;
+}


### PR DESCRIPTION
## Summary
- Add a direct-route alias so `/cc` launches the Countries-Cities game.
- Keep `/countries-cities` as the canonical direct launch route.
- Add focused Vitest coverage for the alias resolver.

## Review
- Reviewed the changed route resolver and alias helper manually.
- Confirmed GitHub Pages SPA fallback should pass `/cc` through the same direct-route resolver.

## Validation
- Added `src/direct/directGameRouteAliases.test.ts`.
- Not run locally: the execution environment could not clone/fetch the repository due DNS/network access, so I could not run `npm test` or `npm run build` here.