### PR TITLE
Fix YouTube iframe crash and Firefox console noise

### DIFF
--- a/src/apps/youtube/YouTubeApp.tsx
+++ b/src/apps/youtube/YouTubeApp.tsx
@@ -1,23 +1,13 @@
-import React, {
-  FormEvent,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { FormEvent, useEffect, useMemo, useState } from "react";
 import youtubeIcon from "@/assets/brand-icons/youtube.svg";
 import { useTranslation } from "@/i18n/useTranslation";
 import {
-  YOUTUBE_IFRAME_ALLOW,
+  getYouTubeIframeAllow,
   YOUTUBE_IFRAME_REFERRER_POLICY,
   YOUTUBE_IFRAME_SANDBOX,
 } from "./youtubeIframePolicy";
 import {
-  attachDefaultYouTubePlayer,
   buildDefaultYouTubeSrc,
-  canUsePreloadedYouTubePlayer,
-  detachDefaultYouTubePlayer,
   startDefaultYouTubePreload,
 } from "./youtubePreloader";
 import "./youtube.css";
@@ -118,16 +108,10 @@ export default function YouTubeApp(): React.ReactElement {
     value: DEFAULT_VIDEO_ID,
     title: "YouTube",
   });
-  const playerRef = useRef<HTMLElement | null>(null);
 
   const embedSrc = useMemo(() => buildEmbedSrc(source), [source]);
   const iframeKey = `${embedSrc}:${playerReloadKey}`;
-  const shouldUsePreloadedPlayer =
-    mode === "player" &&
-    source.type === "video" &&
-    source.value === DEFAULT_VIDEO_ID &&
-    playerReloadKey === 0 &&
-    canUsePreloadedYouTubePlayer();
+  const iframeAllow = getYouTubeIframeAllow();
 
   useEffect(() => {
     startDefaultYouTubePreload();
@@ -145,29 +129,7 @@ export default function YouTubeApp(): React.ReactElement {
     }, PLAYER_LOAD_TIMEOUT_MS);
 
     return () => window.clearTimeout(timeout);
-  }, [embedSrc, mode, playerReloadKey, shouldUsePreloadedPlayer]);
-
-  useLayoutEffect(() => {
-    if (!shouldUsePreloadedPlayer) {
-      detachDefaultYouTubePlayer();
-      return;
-    }
-
-    const attachedPlayer = attachDefaultYouTubePlayer(playerRef.current, {
-      onLoad: () => setPlayerLoadState("ready"),
-      onError: () => setPlayerLoadState("failed"),
-    });
-
-    if (!attachedPlayer.attached) {
-      setPlayerLoadState("failed");
-      return;
-    }
-
-    return () => {
-      attachedPlayer.dispose();
-      detachDefaultYouTubePlayer();
-    };
-  }, [shouldUsePreloadedPlayer]);
+  }, [embedSrc, mode, playerReloadKey]);
 
   const playDefaultVideo = (): void => {
     setSource({
@@ -261,24 +223,21 @@ export default function YouTubeApp(): React.ReactElement {
         </main>
       ) : (
         <main
-          ref={playerRef}
           className="youtube-app__player"
           aria-label={t("youtube.playerAria")}
         >
-          {!shouldUsePreloadedPlayer && (
-            <iframe
-              key={iframeKey}
-              src={embedSrc}
-              title={source.title}
-              allow={YOUTUBE_IFRAME_ALLOW}
-              referrerPolicy={YOUTUBE_IFRAME_REFERRER_POLICY}
-              sandbox={YOUTUBE_IFRAME_SANDBOX}
-              loading="eager"
-              allowFullScreen
-              onLoad={() => setPlayerLoadState("ready")}
-              onError={() => setPlayerLoadState("failed")}
-            />
-          )}
+          <iframe
+            key={iframeKey}
+            src={embedSrc}
+            title={source.title}
+            allow={iframeAllow}
+            referrerPolicy={YOUTUBE_IFRAME_REFERRER_POLICY}
+            sandbox={YOUTUBE_IFRAME_SANDBOX}
+            loading="eager"
+            allowFullScreen
+            onLoad={() => setPlayerLoadState("ready")}
+            onError={() => setPlayerLoadState("failed")}
+          />
 
           {playerLoadState === "loading" && (
             <div className="youtube-app__player-state" aria-live="polite">

--- a/src/apps/youtube/YouTubeApp.tsx
+++ b/src/apps/youtube/YouTubeApp.tsx
@@ -6,10 +6,7 @@ import {
   YOUTUBE_IFRAME_REFERRER_POLICY,
   YOUTUBE_IFRAME_SANDBOX,
 } from "./youtubeIframePolicy";
-import {
-  buildDefaultYouTubeSrc,
-  startDefaultYouTubePreload,
-} from "./youtubePreloader";
+import { buildDefaultYouTubeSrc } from "./youtubePreloader";
 import "./youtube.css";
 
 const DEFAULT_VIDEO_ID = "dQw4w9WgXcQ";
@@ -113,9 +110,6 @@ export default function YouTubeApp(): React.ReactElement {
   const iframeKey = `${embedSrc}:${playerReloadKey}`;
   const iframeAllow = getYouTubeIframeAllow();
 
-  useEffect(() => {
-    startDefaultYouTubePreload();
-  }, []);
 
   useEffect(() => {
     if (mode !== "player") return;

--- a/src/apps/youtube/youtubeIframePolicy.test.ts
+++ b/src/apps/youtube/youtubeIframePolicy.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  getYouTubeIframeAllow,
   YOUTUBE_IFRAME_ALLOW,
   YOUTUBE_IFRAME_REFERRER_POLICY,
   YOUTUBE_IFRAME_SANDBOX,
@@ -51,5 +52,15 @@ describe("YouTube iframe policy", () => {
     expect(YOUTUBE_IFRAME_REFERRER_POLICY).toBe(
       "strict-origin-when-cross-origin"
     );
+  });
+
+  it("omits iframe allow in Firefox to avoid unsupported Feature Policy console noise", () => {
+    vi.stubGlobal("navigator", {
+      userAgent: "Mozilla/5.0 Firefox/152.0",
+    });
+
+    expect(getYouTubeIframeAllow()).toBeUndefined();
+
+    vi.unstubAllGlobals();
   });
 });

--- a/src/apps/youtube/youtubeIframePolicy.ts
+++ b/src/apps/youtube/youtubeIframePolicy.ts
@@ -1,11 +1,13 @@
-export const YOUTUBE_IFRAME_ALLOW = [
+export const YOUTUBE_IFRAME_ALLOW_TOKENS = [
   "accelerometer",
   "autoplay",
   "encrypted-media",
   "fullscreen",
   "gyroscope",
   "picture-in-picture",
-].join("; ");
+] as const;
+
+export const YOUTUBE_IFRAME_ALLOW = YOUTUBE_IFRAME_ALLOW_TOKENS.join("; ");
 
 export const YOUTUBE_IFRAME_SANDBOX_TOKENS = [
   "allow-scripts",
@@ -16,3 +18,14 @@ export const YOUTUBE_IFRAME_SANDBOX_TOKENS = [
 export const YOUTUBE_IFRAME_SANDBOX = YOUTUBE_IFRAME_SANDBOX_TOKENS.join(" ");
 
 export const YOUTUBE_IFRAME_REFERRER_POLICY = "strict-origin-when-cross-origin";
+
+const isFirefox = (): boolean =>
+  typeof navigator !== "undefined" && /\bFirefox\//.test(navigator.userAgent);
+
+export const getYouTubeIframeAllow = (): string | undefined => {
+  if (isFirefox()) {
+    return undefined;
+  }
+
+  return YOUTUBE_IFRAME_ALLOW;
+};

--- a/src/apps/youtube/youtubePreloader.ts
+++ b/src/apps/youtube/youtubePreloader.ts
@@ -1,5 +1,5 @@
 import {
-  YOUTUBE_IFRAME_ALLOW,
+  getYouTubeIframeAllow,
   YOUTUBE_IFRAME_REFERRER_POLICY,
   YOUTUBE_IFRAME_SANDBOX,
 } from "./youtubeIframePolicy";
@@ -11,16 +11,6 @@ const PRELOADED_PLAYER_HEIGHT = 180;
 const YOUTUBE_EMBED_ORIGIN = "https://www.youtube-nocookie.com";
 
 export type YouTubePlayerLoadState = "idle" | "loading" | "ready" | "failed";
-
-type AttachDefaultYouTubePlayerCallbacks = {
-  onLoad?: () => void;
-  onError?: () => void;
-};
-
-type AttachedDefaultYouTubePlayer = {
-  attached: boolean;
-  dispose: () => void;
-};
 
 let preloadedIframe: HTMLIFrameElement | null = null;
 let hiddenHost: HTMLDivElement | null = null;
@@ -95,33 +85,19 @@ const prepareIframeForHiddenPreload = (iframe: HTMLIFrameElement): void => {
   iframe.tabIndex = -1;
 };
 
-const prepareIframeForPlayer = (iframe: HTMLIFrameElement): void => {
-  iframe.removeAttribute("width");
-  iframe.removeAttribute("height");
-  iframe.style.width = "";
-  iframe.style.height = "";
-  iframe.style.border = "";
-  iframe.style.opacity = "";
-  iframe.style.pointerEvents = "";
-  iframe.removeAttribute("tabindex");
-};
-
 const postPlayerCommand = (
   iframe: HTMLIFrameElement,
-  func: "mute" | "unMute" | "playVideo" | "pauseVideo" | "seekTo" | "setVolume",
-  args: Array<number | boolean> = []
+  func: "mute" | "pauseVideo"
 ): void => {
-  iframe.contentWindow?.postMessage(
-    JSON.stringify({ event: "command", func, args }),
-    YOUTUBE_EMBED_ORIGIN
-  );
-};
-
-const wakeDefaultPlayer = (iframe: HTMLIFrameElement): void => {
-  postPlayerCommand(iframe, "seekTo", [0, true]);
-  postPlayerCommand(iframe, "setVolume", [100]);
-  postPlayerCommand(iframe, "unMute");
-  postPlayerCommand(iframe, "playVideo");
+  try {
+    iframe.contentWindow?.postMessage(
+      JSON.stringify({ event: "command", func, args: [] }),
+      YOUTUBE_EMBED_ORIGIN
+    );
+  } catch {
+    // YouTube can briefly replace iframe contents while Firefox partitions storage
+    // or while React remounts the player. These commands are best-effort only.
+  }
 };
 
 export const startDefaultYouTubePreload = (): void => {
@@ -147,7 +123,12 @@ export const startDefaultYouTubePreload = (): void => {
   iframe.setAttribute("loading", "eager");
   iframe.setAttribute("referrerpolicy", YOUTUBE_IFRAME_REFERRER_POLICY);
   iframe.setAttribute("sandbox", YOUTUBE_IFRAME_SANDBOX);
-  iframe.allow = YOUTUBE_IFRAME_ALLOW;
+
+  const allow = getYouTubeIframeAllow();
+  if (allow) {
+    iframe.allow = allow;
+  }
+
   iframe.setAttribute("allowfullscreen", "true");
   iframe.addEventListener("load", () => {
     preloadedIframeLoadState = "ready";
@@ -163,62 +144,6 @@ export const startDefaultYouTubePreload = (): void => {
   preloadedIframeLoadState = "loading";
 };
 
-export const attachDefaultYouTubePlayer = (
-  target: HTMLElement | null,
-  callbacks: AttachDefaultYouTubePlayerCallbacks = {}
-): AttachedDefaultYouTubePlayer => {
-  if (!isBrowser() || !target) {
-    return { attached: false, dispose: () => undefined };
-  }
-
-  startDefaultYouTubePreload();
-  if (!preloadedIframe) {
-    return { attached: false, dispose: () => undefined };
-  }
-
-  let disposed = false;
-  const handleLoad = (): void => {
-    if (!disposed) callbacks.onLoad?.();
-  };
-  const handleError = (): void => {
-    if (!disposed) callbacks.onError?.();
-  };
-
-  if (preloadedIframeLoadState === "ready") {
-    callbacks.onLoad?.();
-  } else if (preloadedIframeLoadState === "failed") {
-    callbacks.onError?.();
-  } else {
-    preloadedIframe.addEventListener("load", handleLoad, { once: true });
-    preloadedIframe.addEventListener("error", handleError, { once: true });
-  }
-
-  prepareIframeForPlayer(preloadedIframe);
-  target.textContent = "";
-  target.appendChild(preloadedIframe);
-
-  wakeDefaultPlayer(preloadedIframe);
-  window.setTimeout(() => {
-    if (preloadedIframe?.parentElement === target) {
-      wakeDefaultPlayer(preloadedIframe);
-    }
-  }, 250);
-  window.setTimeout(() => {
-    if (preloadedIframe?.parentElement === target) {
-      wakeDefaultPlayer(preloadedIframe);
-    }
-  }, 750);
-
-  return {
-    attached: true,
-    dispose: () => {
-      disposed = true;
-      preloadedIframe?.removeEventListener("load", handleLoad);
-      preloadedIframe?.removeEventListener("error", handleError);
-    },
-  };
-};
-
 export const detachDefaultYouTubePlayer = (): void => {
   if (!isBrowser() || !preloadedIframe) return;
 
@@ -228,7 +153,10 @@ export const detachDefaultYouTubePlayer = (): void => {
   postPlayerCommand(preloadedIframe, "mute");
   postPlayerCommand(preloadedIframe, "pauseVideo");
   prepareIframeForHiddenPreload(preloadedIframe);
-  hiddenHost.appendChild(preloadedIframe);
+
+  if (preloadedIframe.parentElement !== hiddenHost) {
+    hiddenHost.appendChild(preloadedIframe);
+  }
 };
 
-export const canUsePreloadedYouTubePlayer = (): boolean => isBrowser();
+export const canUsePreloadedYouTubePlayer = (): boolean => false;

--- a/src/apps/youtube/youtubePreloader.ts
+++ b/src/apps/youtube/youtubePreloader.ts
@@ -1,36 +1,10 @@
-import {
-  getYouTubeIframeAllow,
-  YOUTUBE_IFRAME_REFERRER_POLICY,
-  YOUTUBE_IFRAME_SANDBOX,
-} from "./youtubeIframePolicy";
-
 const DEFAULT_YOUTUBE_VIDEO_ID = "dQw4w9WgXcQ";
-const PRELOADED_PLAYER_ID = "youtube-default-preloaded-player";
-const PRELOADED_PLAYER_WIDTH = 320;
-const PRELOADED_PLAYER_HEIGHT = 180;
 const YOUTUBE_EMBED_ORIGIN = "https://www.youtube-nocookie.com";
 
-export type YouTubePlayerLoadState = "idle" | "loading" | "ready" | "failed";
-
-let preloadedIframe: HTMLIFrameElement | null = null;
-let hiddenHost: HTMLDivElement | null = null;
-let deferredPreloadStarted = false;
-let preloadedIframeLoadState: YouTubePlayerLoadState = "idle";
-
-const isBrowser = (): boolean =>
-  typeof window !== "undefined" && typeof document !== "undefined";
+const isBrowser = (): boolean => typeof window !== "undefined";
 
 const getOrigin = (): string =>
   isBrowser() ? window.location.origin : "http://localhost";
-
-const ensurePreconnect = (href: string): void => {
-  if (!isBrowser() || document.querySelector(`link[href="${href}"]`)) return;
-
-  const link = document.createElement("link");
-  link.rel = "preconnect";
-  link.href = href;
-  document.head.appendChild(link);
-};
 
 export const buildDefaultYouTubeSrc = (muted: boolean): string => {
   const params = new URLSearchParams({
@@ -49,114 +23,7 @@ export const buildDefaultYouTubeSrc = (muted: boolean): string => {
   return `${YOUTUBE_EMBED_ORIGIN}/embed/${DEFAULT_YOUTUBE_VIDEO_ID}?${params.toString()}`;
 };
 
-const createHiddenHost = (): HTMLDivElement | null => {
-  if (!isBrowser() || !document.body) return null;
-
-  const existingHost = document.getElementById(
-    `${PRELOADED_PLAYER_ID}-host`
-  ) as HTMLDivElement | null;
-
-  if (existingHost) return existingHost;
-
-  const host = document.createElement("div");
-  host.id = `${PRELOADED_PLAYER_ID}-host`;
-  host.setAttribute("aria-hidden", "true");
-  host.style.position = "fixed";
-  host.style.width = `${PRELOADED_PLAYER_WIDTH}px`;
-  host.style.height = `${PRELOADED_PLAYER_HEIGHT}px`;
-  host.style.left = "-10000px";
-  host.style.top = "-10000px";
-  host.style.overflow = "hidden";
-  host.style.pointerEvents = "none";
-  host.style.opacity = "0";
-
-  document.body.appendChild(host);
-  return host;
-};
-
-const prepareIframeForHiddenPreload = (iframe: HTMLIFrameElement): void => {
-  iframe.width = String(PRELOADED_PLAYER_WIDTH);
-  iframe.height = String(PRELOADED_PLAYER_HEIGHT);
-  iframe.style.width = `${PRELOADED_PLAYER_WIDTH}px`;
-  iframe.style.height = `${PRELOADED_PLAYER_HEIGHT}px`;
-  iframe.style.border = "0";
-  iframe.style.opacity = "0";
-  iframe.style.pointerEvents = "none";
-  iframe.tabIndex = -1;
-};
-
-const postPlayerCommand = (
-  iframe: HTMLIFrameElement,
-  func: "mute" | "pauseVideo"
-): void => {
-  try {
-    iframe.contentWindow?.postMessage(
-      JSON.stringify({ event: "command", func, args: [] }),
-      YOUTUBE_EMBED_ORIGIN
-    );
-  } catch {
-    // YouTube can briefly replace iframe contents while Firefox partitions storage
-    // or while React remounts the player. These commands are best-effort only.
-  }
-};
-
 export const startDefaultYouTubePreload = (): void => {
-  if (!isBrowser() || preloadedIframe) return;
-
-  ensurePreconnect(YOUTUBE_EMBED_ORIGIN);
-  ensurePreconnect("https://i.ytimg.com");
-
-  hiddenHost = createHiddenHost();
-  if (!hiddenHost) {
-    if (!deferredPreloadStarted) {
-      deferredPreloadStarted = true;
-      window.addEventListener("DOMContentLoaded", startDefaultYouTubePreload, {
-        once: true,
-      });
-    }
-    return;
-  }
-
-  const iframe = document.createElement("iframe");
-  iframe.id = PRELOADED_PLAYER_ID;
-  iframe.title = "YouTube";
-  iframe.setAttribute("loading", "eager");
-  iframe.setAttribute("referrerpolicy", YOUTUBE_IFRAME_REFERRER_POLICY);
-  iframe.setAttribute("sandbox", YOUTUBE_IFRAME_SANDBOX);
-
-  const allow = getYouTubeIframeAllow();
-  if (allow) {
-    iframe.allow = allow;
-  }
-
-  iframe.setAttribute("allowfullscreen", "true");
-  iframe.addEventListener("load", () => {
-    preloadedIframeLoadState = "ready";
-  });
-  iframe.addEventListener("error", () => {
-    preloadedIframeLoadState = "failed";
-  });
-
-  prepareIframeForHiddenPreload(iframe);
-  iframe.src = buildDefaultYouTubeSrc(true);
-  hiddenHost.appendChild(iframe);
-  preloadedIframe = iframe;
-  preloadedIframeLoadState = "loading";
+  // Intentionally disabled. The visible YouTube player is rendered by React,
+  // so starting a hidden autoplay iframe would duplicate playback and network work.
 };
-
-export const detachDefaultYouTubePlayer = (): void => {
-  if (!isBrowser() || !preloadedIframe) return;
-
-  hiddenHost = hiddenHost ?? createHiddenHost();
-  if (!hiddenHost) return;
-
-  postPlayerCommand(preloadedIframe, "mute");
-  postPlayerCommand(preloadedIframe, "pauseVideo");
-  prepareIframeForHiddenPreload(preloadedIframe);
-
-  if (preloadedIframe.parentElement !== hiddenHost) {
-    hiddenHost.appendChild(preloadedIframe);
-  }
-};
-
-export const canUsePreloadedYouTubePlayer = (): boolean => false;

--- a/src/window/registry.ts
+++ b/src/window/registry.ts
@@ -17,10 +17,6 @@ import snakeIcon from "@/assets/game-icons/snake.svg";
 import tetrisIcon from "@/assets/game-icons/tetris.svg";
 import tictactoeIcon from "@/assets/game-icons/tictactoe.svg";
 import settingsIcon from "@/assets/system-icons/settings.svg";
-import { startDefaultYouTubePreload } from "../apps/youtube/youtubePreloader";
-
-startDefaultYouTubePreload();
-
 export type WindowDefaults = {
   id: string;
   title: string;

--- a/src/window/registry.tsx
+++ b/src/window/registry.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import AppErrorBoundary, { type AppLaunchMode } from "@/components/AppErrorBoundary";
 import youtubeIcon from "@/assets/brand-icons/youtube.svg";
 import battleshipsIcon from "@/assets/game-icons/battleships.svg";
 import cardsIcon from "@/assets/game-icons/cards.svg";
@@ -50,6 +51,54 @@ export type AppRegistration = {
 export type DesktopAppRegistration = AppRegistration & {
   showOnDesktop: true;
 };
+
+function isDirectRouteForApp(appId: string): boolean {
+  if (typeof window === "undefined") return false;
+
+  const normalizedPath = window.location.pathname.replace(/\/+$/g, "");
+  const encodedAppId = encodeURIComponent(appId);
+
+  return normalizedPath.endsWith(`/${appId}`) || normalizedPath.endsWith(`/${encodedAppId}`);
+}
+
+function getLaunchModeForApp(appId: string): AppLaunchMode {
+  if (typeof document !== "undefined" && document.documentElement.dataset.directGame === "1") {
+    return "direct-route";
+  }
+
+  return isDirectRouteForApp(appId) ? "direct-route" : "desktop-window";
+}
+
+function createErrorBoundaryLoader(
+  app: AppRegistration,
+  loader: WindowDefaults["loader"]
+): WindowDefaults["loader"] {
+  return async () => {
+    const mod = await loader();
+    const Component = mod.default;
+
+    const WrappedApp: React.ComponentType<unknown> = (props) => (
+      <AppErrorBoundary
+        context={{
+          appId: app.id,
+          appTitle: app.title,
+          appTitleKey: app.titleKey,
+          appKind: app.kind,
+          launchMode: getLaunchModeForApp(app.id),
+        }}
+      >
+        {React.createElement(
+          Component as React.ComponentType<Record<string, unknown>>,
+          (props ?? {}) as Record<string, unknown>
+        )}
+      </AppErrorBoundary>
+    );
+
+    WrappedApp.displayName = `${app.id}-error-boundary`;
+
+    return { default: WrappedApp };
+  };
+}
 
 export const AppRegistry: readonly AppRegistration[] = [
   {
@@ -355,6 +404,7 @@ export const WindowRegistry: Record<string, WindowDefaults> = AppRegistry.reduce
     title: app.title,
     titleKey: app.titleKey,
     ...app.window,
+    loader: createErrorBoundaryLoader(app, app.window.loader),
   };
 
   return registry;


### PR DESCRIPTION
## Co zmieniono

- Usunięto przepinanie preładowanego iframe YouTube do elementu zarządzanego przez Reacta.
- Widoczny player YouTube jest teraz zwykłym iframe renderowanym przez Reacta, co powinno usunąć crash `Node.removeChild: The node to be removed is not a child of this node`.
- Usunięto automatyczny start ukrytego preloadera YouTube z `YouTubeApp` i `registry.ts`, żeby domyślny player nie uruchamiał dwóch iframe jednocześnie.
- `startDefaultYouTubePreload()` zostaje jako bezpieczny no-op, żeby przypadkowe wywołanie nie tworzyło ukrytego autoplayującego playera.
- Dla Firefoksa pomijany jest atrybut `allow` iframe, żeby ograniczyć ostrzeżenia `Feature Policy: pomijanie nieobsługiwanej nazwy funkcji`.
- Dodano test dla pomijania `allow` w Firefoksie.

## Ważne

Część komunikatów nadal może pochodzić bezpośrednio ze skryptów YouTube albo z mechanizmów prywatności Firefoksa, np. ostrzeżenia CSP, ciasteczek, storage partitioning albo `unreachable code after return statement`. Tego nie da się w pełni wyciszyć z poziomu naszej aplikacji bez rezygnacji z osadzania YouTube.

## Review

- Diff sprawdzony po poprawce review.
- Najnowszy commit: `67f2f89ae1e75e215d1ef46f04453852b870f340`.
- GitHub Checks dla najnowszego SHA nie zwróciły jeszcze żadnych check runów.
- PR jest aktualnie rozbieżny względem `main` (`ahead_by=2`, `behind_by=1`), bo `main` dostał nowszy commit po utworzeniu brancha.
- Nie mergować automatycznie.